### PR TITLE
ci: Fix manifest build failing on 'fs' package

### DIFF
--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -21,10 +21,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
-      - name: Install R packages
-        run: |
-          Rscript -e "install.packages(c('jsonlite','stringr','dplyr','lubridate','purrr','fs'), repos='https://cloud.r-project.org')"
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: jsonlite, stringr, dplyr, lubridate, purrr, fs, tibble
 
       - name: Build manifest
         run: |


### PR DESCRIPTION
## Problem

Seit dem 19. April (Albania-Push, Runs #935/#936) und alle nachfolgenden Scheduled-Runs (#937, #938) schlagen fehl mit:

```
there is no package called 'fs'
```

`manifest.json` ist dadurch seit `b015924` (18. April) nicht mehr aktualisiert worden — neue Modelle (Albania 20260419) fehlen im Manifest.

## Root Cause

Im alten Workflow:

```yaml
Rscript -e "install.packages(c('jsonlite','stringr','dplyr','lubridate','purrr','fs'), repos='https://cloud.r-project.org')"
```

Zwei Probleme:

1. **`install.packages()` bricht nicht ab, wenn ein Paket nicht verfügbar ist** — es gibt nur eine Warning. Der Install-Step läuft grün durch, und erst `library(fs)` stirbt später. Zwischen 18. und 19. April hat sich die R-/CRAN-Umgebung auf `ubuntu-latest` so geändert, dass `fs` nicht mehr aus den Sourcen gebaut werden kann (vermutlich neues R-Release → noch kein passendes CRAN-Source/Binary).
2. **`library(tibble)` wird in `build_manifest.R` geladen, steht aber nicht in der Install-Liste.** Funktioniert aktuell nur, weil `dplyr` es transitiv mitzieht — fragil.

## Fix

```yaml
- uses: r-lib/actions/setup-r@v2
  with:
    use-public-rspm: true

- uses: r-lib/actions/setup-r-dependencies@v2
  with:
    packages: jsonlite, stringr, dplyr, lubridate, purrr, fs, tibble
```

- `use-public-rspm: true` zieht Linux-Binaries vom Posit Public Package Manager → kein Source-Build nötig, deutlich schneller und zuverlässiger.
- `setup-r-dependencies@v2` bricht hart ab, wenn Pakete fehlen, und cached Dependencies.
- `tibble` ist jetzt explizit drin.

## Test plan

- [ ] PR mergen (oder `workflow_dispatch` auf diesem Branch starten)
- [ ] Build-manifest-Run sollte grün durchlaufen
- [ ] `manifest.json` auf `master` sollte anschließend `albania_*_20260419.png`-Einträge enthalten und `"updated"` auf das heutige Datum aktualisiert sein