### PR TITLE
fix: set showtext dpi=300 so action renders match local text sizes

### DIFF
--- a/R/render_country.R
+++ b/R/render_country.R
@@ -53,6 +53,9 @@ social_caption <- if (have_fonts) {
   try(font_add(family = "Font Awesome 6 Brands", regular = font_brands), silent = TRUE)
   try(font_add(family = "CustomIcons", regular = font_custom), silent = TRUE)
   showtext_auto()
+  # Match showtext's text-rendering DPI to ggsave's canvas DPI. Without this,
+  # showtext renders at 96 dpi on a 300 dpi canvas → text comes out ~32% size.
+  showtext_opts(dpi = 300)
   glue::glue(
     "<span style='font-family:\"CustomIcons\";'>&#xe900;</span>",
     "<span style='font-family:\"Font Awesome 6 Brands\";'>&#xe61b;</span> <span style='color:#000000'>leraffl</span>",


### PR DESCRIPTION
## Why

The render Action's output had titles, captions and axis labels rendered at ~32% of intended size. Cause: `showtext_auto()` is enabled so all text goes through showtext, which defaults to 96 dpi for rasterization. `ggsave()` writes a 300 dpi canvas. The 96/300 ratio is exactly the visible shrink.

Locally on a macOS R session, showtext picks up the screen device dpi and the mismatch isn't visible — only headless CI renders are affected, which is why the issue only surfaced after running the workflow.

## Fix

One line in `R/render_country.R`: call `showtext_opts(dpi = 300)` right after `showtext_auto()` so showtext rasterizes at the same dpi `ggsave` writes.

## Test plan
- [ ] Merge.
- [ ] Re-run `Render country charts` Action with `country=Germany`.
- [ ] Compare resulting PNGs against `images/2026-04/germany_*` (last pre-CI local renders) — text sizes should match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)