### PR TITLE
feat: Submit Data tab + worker /submissions endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -670,6 +670,38 @@ dialog#feedbackModal::backdrop{background:rgba(0,0,0,.65)}
    weight as the surrounding h2 text and stay tappable on mobile. */
 h2 .fb-ctx-cluster{margin-left:10px;font-size:initial;font-weight:400}
 h2 .fb-ctx-btn{width:30px;height:30px;font-size:16px;opacity:.6}
+
+/* ── Submit Data tab ──────────────────────────────────────────────────── */
+.sd-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:14px;margin:14px 0}
+.sd-grid .sd-field{display:flex;flex-direction:column;gap:6px}
+.sd-grid label{font-size:.85em;color:#8aa0c8}
+.sd-grid input,.sd-grid select{background:#0b1324;color:#e9eef2;border:1px solid #2a3654;border-radius:6px;padding:8px 10px;font-size:.95em}
+.sd-grid input:focus,.sd-grid select:focus{outline:none;border-color:#5b87ff}
+.sd-rows{margin-top:18px;border:1px solid #1f2a44;border-radius:10px;overflow:hidden}
+.sd-row{padding:14px;border-bottom:1px solid #1f2a44;background:#0f1525}
+.sd-row:last-child{border-bottom:none}
+.sd-row-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px}
+.sd-row-head .sd-row-title{font-weight:600}
+.sd-row-head .sd-row-rm{background:transparent;border:1px solid #2a3654;color:#e9eef2;border-radius:6px;padding:4px 10px;cursor:pointer;font-size:.85em}
+.sd-row-head .sd-row-rm:hover{background:#3a1f24;border-color:#6a3a40}
+.sd-row-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:10px}
+.sd-row-grid .sd-cell{display:flex;flex-direction:column;gap:4px}
+.sd-row-grid .sd-cell label{font-size:.75em;color:#8aa0c8;text-transform:uppercase;letter-spacing:.04em}
+.sd-row-grid .sd-cell input,.sd-row-grid .sd-cell select{background:#0b1324;color:#e9eef2;border:1px solid #2a3654;border-radius:6px;padding:6px 8px;font-size:.9em}
+.sd-row-sumcheck{margin-top:8px;font-size:.8em;color:#8aa0c8}
+.sd-row-sumcheck.bad{color:#ff8a8a}
+.sd-row-sumcheck.good{color:#7adba0}
+.sd-actions{display:flex;gap:10px;margin-top:14px;align-items:center;flex-wrap:wrap}
+.sd-add{background:transparent;border:1px dashed #2a3654;color:#e9eef2;border-radius:8px;padding:10px 14px;cursor:pointer;font-size:.95em}
+.sd-add:hover{background:#0f1525;border-style:solid}
+.sd-submit{background:#33A1FF;color:#0b0c10;border:none;border-radius:8px;padding:10px 18px;cursor:pointer;font-size:.95em;font-weight:600}
+.sd-submit:hover{background:#5cb6ff}
+.sd-submit[disabled]{opacity:.5;cursor:not-allowed}
+.sd-msg{margin-top:14px;padding:12px;border-radius:8px}
+.sd-msg.error{background:#3a1f24;border:1px solid #6a3a40;color:#ffb3b3}
+.sd-msg.success{background:#1f3a24;border:1px solid #3a6a40;color:#b3ffb3}
+.sd-help{font-size:.85em;color:#8aa0c8;max-width:80ch;line-height:1.45}
+.sd-help code{background:#0b1324;padding:1px 5px;border-radius:3px}
 </style>
   
 
@@ -711,6 +743,7 @@ h2 .fb-ctx-btn{width:30px;height:30px;font-size:16px;opacity:.6}
     <a href="#fleet" class="tablink">Fleet</a>
     <a href="#worldmap" class="tablink">World Map</a>
     <a href="#faq" class="tablink">FAQ</a>
+    <a href="#submit" class="tablink">Submit Data</a>
     <a href="#feedback" class="tablink">Feedback &amp; Questions</a>
   </nav>
 
@@ -729,6 +762,52 @@ h2 .fb-ctx-btn{width:30px;height:30px;font-size:16px;opacity:.6}
     <input id="faqSearch" placeholder="Search FAQ..." style="width:100%;padding:8px;margin-bottom:14px">
     <!-- Cards are rendered from FAQ_DATA in the script block below. -->
     <div id="faqList"></div>
+  </div>
+</section>
+
+<!-- SUBMIT DATA TAB
+     Form posts to the Cloudflare Worker's /submissions endpoint, which
+     opens a PR against data/<Country>.csv for review. New rows are added,
+     existing periods (same variant) are corrected by overwrite. -->
+<section id="tab-submit" class="tab">
+  <div class="container">
+    <h2>Submit Data</h2>
+    <p class="sd-help">
+      Add a new monthly data point or correct an existing one. The form opens
+      a pull request against the country's CSV in this repo, the maintainer
+      reviews and merges, then triggers the render Action — your numbers
+      appear on the page within a few minutes after merge. Multiple rows
+      (multiple months / corrections) can ship in one submission.
+    </p>
+
+    <div class="sd-grid">
+      <div class="sd-field">
+        <label for="sdCountry">Country</label>
+        <select id="sdCountry"></select>
+      </div>
+      <div class="sd-field">
+        <label for="sdVariant">Variant</label>
+        <select id="sdVariant"><option value="Whole">Whole (= "New Cars")</option></select>
+      </div>
+      <div class="sd-field">
+        <label for="sdSource">Source (URL or short name)</label>
+        <input id="sdSource" type="text" placeholder="e.g. KBA or kba.de/…" maxlength="200">
+      </div>
+    </div>
+
+    <div class="sd-rows" id="sdRows"></div>
+
+    <div class="sd-actions">
+      <button type="button" class="sd-add" id="sdAddRow">+ Add another month</button>
+      <span style="flex:1"></span>
+      <input id="sdAuthor" type="text" placeholder="Your name (optional)" maxlength="40" style="background:#0b1324;color:#e9eef2;border:1px solid #2a3654;border-radius:6px;padding:8px 10px">
+      <button type="button" class="sd-submit" id="sdSubmit">Submit for review</button>
+    </div>
+
+    <!-- Honeypot: hidden via inline style so casual scrapers fill it. -->
+    <input id="sdHp" type="text" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px" aria-hidden="true">
+
+    <div class="sd-msg" id="sdMsg" hidden></div>
   </div>
 </section>
 
@@ -5600,6 +5679,234 @@ function fbWireEvents(){
 // Preload mock data once on boot so the modal's similar-issue hint works
 // from any tab (via the FAB) without a perceptible first-open delay.
 window.addEventListener('DOMContentLoaded', () => { fbWireEvents(); fbLoad(); });
+
+// =========================================================================
+// SUBMIT-DATA TAB — talks to the same Cloudflare Worker (POST /submissions),
+// which opens a PR against data/<Country>.csv for review.
+// =========================================================================
+
+// Hardcoded for v1: only countries with a data/<Country>.csv that the render
+// pipeline can consume. Extend as more countries get a CSV.
+const SD_COUNTRIES = [
+  { country: 'Germany', variants: ['Whole'] },
+];
+
+// Fuel columns we render inputs for, in canonical order. Per-country we only
+// show the ones that exist in that country's CSV header.
+const SD_FUEL_ORDER = ['BEV','PHEV','EREV','HEV','MHEV','PETROL','DIESEL','GAS','CNG','LPG','FLEXFUEL','ETHANOL','OTHERS','TOTAL'];
+
+const SD_RAW_BASE = 'https://raw.githubusercontent.com/LeRaffl/LeRaffl-Gallery/master/data';
+
+const SD_STATE = {
+  countryCols: null,   // array of fuel columns for the currently selected country
+  rowCount: 0,
+  defaultSource: '',   // remembered from CSV's most-recent row
+};
+
+function sdEl(id) { return document.getElementById(id); }
+
+function sdInit() {
+  const csel = sdEl('sdCountry');
+  csel.innerHTML = SD_COUNTRIES.map(c => `<option value="${c.country}">${c.country}</option>`).join('');
+  csel.addEventListener('change', sdOnCountryChange);
+  sdEl('sdAddRow').addEventListener('click', () => sdAddRow());
+  sdEl('sdSubmit').addEventListener('click', sdSubmit);
+  sdOnCountryChange();
+}
+
+async function sdOnCountryChange() {
+  const country = sdEl('sdCountry').value;
+  const variant = sdEl('sdVariant').value || 'Whole';
+  const filename = variant === 'Whole' ? `${country}.csv` : `${country}_${variant}.csv`;
+  sdMsg('', null);
+
+  // Fetch the CSV header (and last row's source as a default).
+  let cols = SD_FUEL_ORDER;  // fall back to canonical full set
+  let lastSource = '';
+  try {
+    const res = await fetch(`${SD_RAW_BASE}/${encodeURIComponent(filename)}`, { cache: 'no-store' });
+    if (res.ok) {
+      const text = await res.text();
+      const lines = text.split(/\r?\n/).filter(Boolean);
+      if (lines.length) {
+        const header = lines[0].split(',');
+        const fuels  = header.filter(h => SD_FUEL_ORDER.includes(h));
+        if (fuels.length) cols = fuels;
+        const sourceIdx = header.indexOf('source');
+        if (sourceIdx >= 0 && lines.length > 1) {
+          lastSource = lines[lines.length - 1].split(',')[sourceIdx] || '';
+        }
+      }
+    }
+  } catch (_) { /* no network / first-time country: use defaults */ }
+
+  SD_STATE.countryCols = cols;
+  SD_STATE.defaultSource = lastSource;
+  if (lastSource && !sdEl('sdSource').value) sdEl('sdSource').value = lastSource;
+
+  // Reset rows
+  sdEl('sdRows').innerHTML = '';
+  SD_STATE.rowCount = 0;
+  sdAddRow();
+}
+
+function sdAddRow() {
+  const idx = SD_STATE.rowCount++;
+  const cols = SD_STATE.countryCols || SD_FUEL_ORDER;
+  const today = new Date();
+  const defaultPeriod = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}`;
+
+  const fuelCellsHtml = cols.map(c => `
+    <div class="sd-cell">
+      <label>${c}</label>
+      <input type="number" min="0" step="any" data-fuel="${c}" placeholder="0">
+    </div>`).join('');
+
+  const html = `
+    <div class="sd-row" data-row-idx="${idx}">
+      <div class="sd-row-head">
+        <span class="sd-row-title">Row ${idx + 1}</span>
+        ${idx > 0 ? '<button type="button" class="sd-row-rm">Remove</button>' : ''}
+      </div>
+      <div class="sd-row-grid">
+        <div class="sd-cell">
+          <label>Period (YYYY-MM)</label>
+          <input type="month" data-field="period" value="${defaultPeriod}">
+        </div>
+        <div class="sd-cell">
+          <label>Time interval</label>
+          <select data-field="time_interval">
+            <option value="monthly" selected>monthly</option>
+            <option value="quarterly">quarterly</option>
+            <option value="yearly">yearly</option>
+          </select>
+        </div>
+        ${fuelCellsHtml}
+        <div class="sd-cell" style="grid-column:span 2">
+          <label>Notes (optional)</label>
+          <input type="text" data-field="notes" maxlength="200" placeholder="e.g. preliminary, methodology change">
+        </div>
+      </div>
+      <div class="sd-row-sumcheck" data-sumcheck></div>
+    </div>`;
+
+  const wrap = document.createElement('div');
+  wrap.innerHTML = html;
+  const node = wrap.firstElementChild;
+  sdEl('sdRows').appendChild(node);
+
+  node.querySelector('.sd-row-rm')?.addEventListener('click', () => { node.remove(); sdRenumber(); });
+  node.querySelectorAll('input[data-fuel]').forEach(inp => {
+    inp.addEventListener('input', () => sdUpdateSumcheck(node));
+  });
+  sdUpdateSumcheck(node);
+}
+
+function sdRenumber() {
+  [...document.querySelectorAll('#sdRows .sd-row')].forEach((node, i) => {
+    node.querySelector('.sd-row-title').textContent = `Row ${i + 1}`;
+  });
+}
+
+function sdUpdateSumcheck(node) {
+  const fuels = {};
+  node.querySelectorAll('input[data-fuel]').forEach(inp => {
+    const v = inp.value.trim();
+    if (v !== '') fuels[inp.dataset.fuel] = Number(v);
+  });
+  const el = node.querySelector('[data-sumcheck]');
+  if (fuels.TOTAL === undefined) { el.textContent = ''; el.className = 'sd-row-sumcheck'; return; }
+
+  const cats = ['BEV','PHEV','EREV','HEV','MHEV','PETROL','DIESEL','GAS','CNG','LPG','FLEXFUEL','ETHANOL','OTHERS'];
+  const sum = cats.reduce((s, k) => s + (fuels[k] || 0), 0);
+  const total = fuels.TOTAL;
+  const diff = sum - total;
+  const pct = total ? (Math.abs(diff) / total * 100) : 0;
+
+  if (sum === 0) { el.textContent = 'Categories sum: 0 — only TOTAL set.'; el.className = 'sd-row-sumcheck'; return; }
+  if (Math.abs(diff) < 1 || pct < 0.5) {
+    el.textContent = `Categories sum: ${sum.toLocaleString()} ≈ TOTAL (${total.toLocaleString()})`;
+    el.className = 'sd-row-sumcheck good';
+  } else {
+    el.textContent = `Categories sum: ${sum.toLocaleString()} vs TOTAL ${total.toLocaleString()} (off by ${diff.toLocaleString()}, ${pct.toFixed(1)}%) — please double-check.`;
+    el.className = 'sd-row-sumcheck bad';
+  }
+}
+
+function sdMsg(text, kind) {
+  const el = sdEl('sdMsg');
+  if (!text) { el.hidden = true; el.textContent = ''; el.className = 'sd-msg'; return; }
+  el.hidden = false; el.className = `sd-msg ${kind || ''}`; el.innerHTML = text;
+}
+
+async function sdSubmit() {
+  sdMsg('', null);
+  const btn = sdEl('sdSubmit');
+  btn.disabled = true;
+
+  const country = sdEl('sdCountry').value;
+  const variant = sdEl('sdVariant').value || 'Whole';
+  const source  = sdEl('sdSource').value.trim();
+  const author  = sdEl('sdAuthor').value.trim();
+  const _hp     = sdEl('sdHp').value;
+
+  if (!source) {
+    sdMsg('Source is required (URL or short publisher name).', 'error');
+    btn.disabled = false; return;
+  }
+
+  const rows = [];
+  for (const node of document.querySelectorAll('#sdRows .sd-row')) {
+    const period   = node.querySelector('[data-field=period]').value;
+    const interval = node.querySelector('[data-field=time_interval]').value;
+    const notes    = node.querySelector('[data-field=notes]').value;
+    if (!period) { sdMsg('Each row needs a period (YYYY-MM).', 'error'); btn.disabled = false; return; }
+    const fuels = {};
+    node.querySelectorAll('input[data-fuel]').forEach(inp => {
+      const v = inp.value.trim();
+      if (v !== '') fuels[inp.dataset.fuel] = Number(v);
+    });
+    if (fuels.TOTAL === undefined || fuels.BEV === undefined) {
+      sdMsg(`Row ${period}: BEV and TOTAL are required.`, 'error');
+      btn.disabled = false; return;
+    }
+    rows.push({ period, time_interval: interval, fuels, notes });
+  }
+  if (!rows.length) { sdMsg('At least one row required.', 'error'); btn.disabled = false; return; }
+
+  try {
+    const res = await fetch(`${FB_API}/submissions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ country, variant, source, author, rows, _hp }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      sdMsg(`Submission failed: ${data.error || res.statusText}`, 'error');
+      btn.disabled = false; return;
+    }
+    if (data.pr_url) {
+      sdMsg(
+        `Thanks! Submission opened as <a href="${data.pr_url}" target="_blank" rel="noopener">PR #${data.pr_number}</a> — ` +
+        `${data.summary?.added || 0} added, ${data.summary?.replaced || 0} corrected. ` +
+        `The maintainer will review and merge.`,
+        'success'
+      );
+      // Clear rows so user can submit another batch without restart.
+      sdEl('sdRows').innerHTML = '';
+      SD_STATE.rowCount = 0;
+      sdAddRow();
+    } else {
+      sdMsg('Submission accepted (no changes).', 'success');
+    }
+  } catch (e) {
+    sdMsg(`Network error: ${e.message}`, 'error');
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+window.addEventListener('DOMContentLoaded', sdInit);
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5750,11 +5750,56 @@ async function sdOnCountryChange() {
   sdAddRow();
 }
 
+// English month/quarter labels — keep the picker locale-independent so
+// every visitor sees the same UI regardless of their browser's language.
+const SD_MONTH_NAMES = ['January','February','March','April','May','June',
+                        'July','August','September','October','November','December'];
+const SD_QUARTERS = [
+  { value: 1, label: 'Q1 (Jan–Mar)', month: 2 },   // mid-quarter month — convention asked for
+  { value: 2, label: 'Q2 (Apr–Jun)', month: 5 },
+  { value: 3, label: 'Q3 (Jul–Sep)', month: 8 },
+  { value: 4, label: 'Q4 (Oct–Dec)', month: 11 },
+];
+const SD_YEAR_MIN = 2010;
+function sdYearMax() { return new Date().getFullYear() + 1; }
+function sdYearOptions(selected) {
+  const out = [];
+  for (let y = sdYearMax(); y >= SD_YEAR_MIN; y--) {
+    out.push(`<option value="${y}"${y === selected ? ' selected' : ''}>${y}</option>`);
+  }
+  return out.join('');
+}
+
+// Compose period (YYYY-MM) from interval + dropdown values.
+function sdComposePeriod(interval, year, month, quarter) {
+  if (!year) return '';
+  if (interval === 'yearly')    return `${year}-07`;
+  if (interval === 'quarterly') {
+    const q = SD_QUARTERS.find(x => x.value === quarter);
+    return q ? `${year}-${String(q.month).padStart(2, '0')}` : '';
+  }
+  if (!month) return '';
+  return `${year}-${String(month).padStart(2, '0')}`;
+}
+
+// Human-readable label for the current period (used as the row's title).
+function sdPeriodLabel(interval, year, month, quarter) {
+  if (!year) return 'New entry';
+  if (interval === 'yearly')    return String(year);
+  if (interval === 'quarterly') {
+    const q = SD_QUARTERS.find(x => x.value === quarter);
+    return q ? `Q${q.value} ${year}` : 'New entry';
+  }
+  if (!month) return 'New entry';
+  return `${SD_MONTH_NAMES[month - 1]} ${year}`;
+}
+
 function sdAddRow() {
   const idx = SD_STATE.rowCount++;
   const cols = SD_STATE.countryCols || SD_FUEL_ORDER;
   const today = new Date();
-  const defaultPeriod = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}`;
+  const defaultYear  = today.getFullYear();
+  const defaultMonth = today.getMonth() + 1;
 
   const fuelCellsHtml = cols.map(c => `
     <div class="sd-cell">
@@ -5765,25 +5810,39 @@ function sdAddRow() {
   const html = `
     <div class="sd-row" data-row-idx="${idx}">
       <div class="sd-row-head">
-        <span class="sd-row-title">Row ${idx + 1}</span>
+        <span class="sd-row-title">New entry</span>
         ${idx > 0 ? '<button type="button" class="sd-row-rm">Remove</button>' : ''}
       </div>
       <div class="sd-row-grid">
         <div class="sd-cell">
-          <label>Period (YYYY-MM)</label>
-          <input type="month" data-field="period" value="${defaultPeriod}">
-        </div>
-        <div class="sd-cell">
           <label>Time interval</label>
           <select data-field="time_interval">
-            <option value="monthly" selected>monthly</option>
-            <option value="quarterly">quarterly</option>
-            <option value="yearly">yearly</option>
+            <option value="monthly" selected>Monthly</option>
+            <option value="quarterly">Quarterly</option>
+            <option value="yearly">Yearly</option>
           </select>
         </div>
+        <div class="sd-cell" data-period-cell="month" hidden>
+          <label>Month</label>
+          <select data-field="month">
+            ${SD_MONTH_NAMES.map((n, i) =>
+              `<option value="${i + 1}"${(i + 1) === defaultMonth ? ' selected' : ''}>${n}</option>`).join('')}
+          </select>
+        </div>
+        <div class="sd-cell" data-period-cell="quarter" hidden>
+          <label>Quarter</label>
+          <select data-field="quarter">
+            ${SD_QUARTERS.map(q =>
+              `<option value="${q.value}">${q.label}</option>`).join('')}
+          </select>
+        </div>
+        <div class="sd-cell" data-period-cell="year">
+          <label>Year</label>
+          <select data-field="year">${sdYearOptions(defaultYear)}</select>
+        </div>
         ${fuelCellsHtml}
-        <div class="sd-cell" style="grid-column:span 2">
-          <label>Notes (optional)</label>
+        <div class="sd-cell" style="grid-column:1 / -1">
+          <label>Notes (optional, saved to the CSV's notes column)</label>
           <input type="text" data-field="notes" maxlength="200" placeholder="e.g. preliminary, methodology change">
         </div>
       </div>
@@ -5795,17 +5854,41 @@ function sdAddRow() {
   const node = wrap.firstElementChild;
   sdEl('sdRows').appendChild(node);
 
-  node.querySelector('.sd-row-rm')?.addEventListener('click', () => { node.remove(); sdRenumber(); });
+  node.querySelector('.sd-row-rm')?.addEventListener('click', () => { node.remove(); });
   node.querySelectorAll('input[data-fuel]').forEach(inp => {
     inp.addEventListener('input', () => sdUpdateSumcheck(node));
   });
+
+  const intervalSel = node.querySelector('[data-field=time_interval]');
+  const refresh = () => sdRefreshRowPeriod(node);
+  intervalSel.addEventListener('change', refresh);
+  ['month','quarter','year'].forEach(f => {
+    node.querySelector(`[data-field=${f}]`).addEventListener('change', refresh);
+  });
+  refresh();
   sdUpdateSumcheck(node);
 }
 
-function sdRenumber() {
-  [...document.querySelectorAll('#sdRows .sd-row')].forEach((node, i) => {
-    node.querySelector('.sd-row-title').textContent = `Row ${i + 1}`;
-  });
+// Show only the period inputs relevant to the current interval, then update
+// the row's title accordingly.
+function sdRefreshRowPeriod(node) {
+  const interval = node.querySelector('[data-field=time_interval]').value;
+  node.querySelector('[data-period-cell=month]').hidden   = interval !== 'monthly';
+  node.querySelector('[data-period-cell=quarter]').hidden = interval !== 'quarterly';
+
+  const year    = parseInt(node.querySelector('[data-field=year]').value, 10);
+  const month   = parseInt(node.querySelector('[data-field=month]').value, 10);
+  const quarter = parseInt(node.querySelector('[data-field=quarter]').value, 10);
+  node.querySelector('.sd-row-title').textContent = sdPeriodLabel(interval, year, month, quarter);
+}
+
+// Read composed period from a row node.
+function sdRowPeriod(node) {
+  const interval = node.querySelector('[data-field=time_interval]').value;
+  const year     = parseInt(node.querySelector('[data-field=year]').value, 10);
+  const month    = parseInt(node.querySelector('[data-field=month]').value, 10);
+  const quarter  = parseInt(node.querySelector('[data-field=quarter]').value, 10);
+  return { interval, period: sdComposePeriod(interval, year, month, quarter) };
 }
 
 function sdUpdateSumcheck(node) {
@@ -5857,10 +5940,9 @@ async function sdSubmit() {
 
   const rows = [];
   for (const node of document.querySelectorAll('#sdRows .sd-row')) {
-    const period   = node.querySelector('[data-field=period]').value;
-    const interval = node.querySelector('[data-field=time_interval]').value;
+    const { interval, period } = sdRowPeriod(node);
     const notes    = node.querySelector('[data-field=notes]').value;
-    if (!period) { sdMsg('Each row needs a period (YYYY-MM).', 'error'); btn.disabled = false; return; }
+    if (!period) { sdMsg('Each row needs a period (year/month/quarter).', 'error'); btn.disabled = false; return; }
     const fuels = {};
     node.querySelectorAll('input[data-fuel]').forEach(inp => {
       const v = inp.value.trim();

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,11 +1,15 @@
 /**
- * Cloudflare Worker — LeRaffl Gallery feedback proxy
+ * Cloudflare Worker — LeRaffl Gallery proxy
  *
  * GET  /issues          → fetch GitHub issues, map to our shape, cache 60 s
  * POST /issues          → validate + create a new GitHub issue
+ * POST /submissions     → validate, upsert rows into data/<Country>.csv on a
+ *                         new branch, open a PR for review
  *
  * Required secret (set via `wrangler secret put GITHUB_TOKEN`):
- *   GITHUB_TOKEN  — fine-grained PAT, Issues: Read+Write on leraffl-gallery
+ *   GITHUB_TOKEN — fine-grained PAT on leraffl-gallery with
+ *     Issues: Read+Write, Contents: Read+Write,
+ *     Pull requests: Read+Write, Metadata: Read.
  */
 
 const GITHUB_OWNER = 'leraffl';
@@ -291,6 +295,377 @@ export default {
       if (method === 'POST') return handlePost(request, env, ctx);
     }
 
+    if (url.pathname === '/submissions' && method === 'POST') {
+      return handleSubmission(request, env, ctx);
+    }
+
     return new Response('Not found', { status: 404, headers: corsHeaders(origin) });
   },
 };
+
+// ── POST /submissions ────────────────────────────────────────────────────────
+// Body shape:
+// {
+//   country: "Germany",
+//   variant: "Whole",
+//   source:  "KBA",
+//   rows: [
+//     { period: "2026-04", time_interval: "monthly",
+//       fuels: { BEV: 70000, PHEV: 30000, HEV: 87000, PETROL: 67000,
+//                DIESEL: 38000, OTHERS: 1000, TOTAL: 293000 },
+//       notes: "" }
+//   ],
+//   author: "optional name",
+//   _hp: ""  // honeypot
+// }
+//
+// Per-row upsert key is (period, variant). Existing rows for the same key are
+// replaced; new rows are inserted in chronological order. The CSV's existing
+// column set is preserved — we only overwrite the columns the submission
+// names. New fuel categories not currently in the CSV are appended as new
+// columns (so submitting EREV for a country that didn't have it adds the
+// column with NA in pre-existing rows).
+
+const ALLOWED_TIME_INTERVALS = new Set(['monthly', 'quarterly', 'yearly']);
+const ALLOWED_FUEL_COLS = new Set([
+  'BEV','PHEV','EREV','HEV','MHEV','PETROL','DIESEL','GAS','CNG','LPG',
+  'FLEXFUEL','ETHANOL','OTHERS','TOTAL'
+]);
+
+async function handleSubmission(request, env, ctx) {
+  const origin = request.headers.get('Origin') || '';
+  const ip     = request.headers.get('CF-Connecting-IP') || 'unknown';
+
+  // Rate limit (separate bucket from feedback so a chatty submitter doesn't
+  // lock themselves out of asking questions).
+  if (env.RATE_KV) {
+    const kvKey  = `sub:${ip}`;
+    const stored = await env.RATE_KV.get(kvKey);
+    const count  = stored ? parseInt(stored, 10) : 0;
+    if (count >= RATE_LIMIT_MAX) {
+      return err('Too many submissions. Please try again later.', 429, origin);
+    }
+    ctx.waitUntil(
+      env.RATE_KV.put(kvKey, String(count + 1), { expirationTtl: RATE_LIMIT_WINDOW })
+    );
+  }
+
+  let payload;
+  try { payload = await request.json(); }
+  catch (_) { return err('Invalid JSON body', 400, origin); }
+
+  if (payload._hp && payload._hp !== '') {
+    return json({ ok: true, pr_url: null }, 200, origin);  // silently swallow bots
+  }
+
+  const { country, variant = 'Whole', source = '', rows = [], author = 'Anonymous' } = payload;
+
+  if (typeof country !== 'string' || !country.trim()) return err('country is required', 400, origin);
+  if (typeof variant !== 'string' || !variant.trim()) return err('variant is required', 400, origin);
+  if (!Array.isArray(rows) || rows.length === 0)      return err('at least one row required', 400, origin);
+  if (rows.length > 36)                               return err('too many rows in one submission', 400, origin);
+
+  // Validate each row.
+  const safeRows = [];
+  for (const r of rows) {
+    if (!r || typeof r !== 'object')                  return err('invalid row', 400, origin);
+    if (!/^\d{4}-\d{2}$/.test(String(r.period || ''))) return err(`invalid period "${r.period}" (expected YYYY-MM)`, 400, origin);
+    if (!ALLOWED_TIME_INTERVALS.has(r.time_interval)) return err(`invalid time_interval "${r.time_interval}"`, 400, origin);
+    const fuels = r.fuels || {};
+    if (typeof fuels !== 'object')                    return err('row.fuels must be an object', 400, origin);
+    const cleanFuels = {};
+    for (const [k, v] of Object.entries(fuels)) {
+      if (!ALLOWED_FUEL_COLS.has(k))                  return err(`unknown fuel column "${k}"`, 400, origin);
+      if (v === '' || v === null || v === undefined) continue;
+      const n = Number(v);
+      if (!Number.isFinite(n) || n < 0)               return err(`fuel ${k} must be a non-negative number`, 400, origin);
+      cleanFuels[k] = n;
+    }
+    if (cleanFuels.TOTAL === undefined)               return err(`row ${r.period}: TOTAL is required`, 400, origin);
+    if (cleanFuels.BEV === undefined)                 return err(`row ${r.period}: BEV is required`, 400, origin);
+    // Sum sanity check: BEV + PHEV + EREV must not exceed TOTAL.
+    const bev = cleanFuels.BEV || 0, phev = cleanFuels.PHEV || 0, erev = cleanFuels.EREV || 0;
+    if (bev + phev + erev > cleanFuels.TOTAL * 1.005) {
+      return err(`row ${r.period}: BEV+PHEV+EREV exceeds TOTAL`, 400, origin);
+    }
+    safeRows.push({
+      period:        r.period,
+      time_interval: r.time_interval,
+      fuels:         cleanFuels,
+      notes:         (typeof r.notes === 'string' ? r.notes : '').slice(0, 200),
+    });
+  }
+
+  const safeCountry = country.trim().slice(0, 60);
+  const safeVariant = variant.trim().slice(0, 30);
+  const safeSource  = (source || '').trim().slice(0, 200);
+  const safeAuthor  = (author || 'Anonymous').trim().slice(0, 60) || 'Anonymous';
+
+  // ── Read current data/<Country>.csv from GitHub ──
+  // Filename: matches render_country.R's expectation.
+  // Whole variant → data/<Country>.csv ; non-Whole → data/<Country>_<Variant>.csv
+  const filename = safeVariant === 'Whole'
+    ? `data/${safeCountry}.csv`
+    : `data/${safeCountry}_${safeVariant}.csv`;
+
+  const token = env.GITHUB_TOKEN;
+  const fileRes = await ghFetch(`/contents/${encodeURIComponent(filename).replace(/%2F/g, '/')}?ref=master`, token);
+  let existing = null;   // { sha, content (utf8 string) }
+  if (fileRes.status === 200) {
+    const fileJson = await fileRes.json();
+    existing = { sha: fileJson.sha, content: atob((fileJson.content || '').replace(/\n/g, '')) };
+  } else if (fileRes.status !== 404) {
+    return err(`Failed to read ${filename}`, 502, origin);
+  }
+
+  // ── Apply upserts ──
+  const { newCsv, summary } = upsertRows(existing?.content, safeVariant, safeSource, safeRows);
+
+  if (newCsv === existing?.content) {
+    return err('Submission would not change the file (identical to current data).', 400, origin);
+  }
+
+  // ── Branch name ──
+  const ts = new Date().toISOString().replace(/[:.TZ-]/g, '').slice(0, 14);
+  const slug = `${safeCountry}-${safeVariant}`.replace(/[^A-Za-z0-9]+/g, '-').toLowerCase();
+  const branch = `submit/${slug}-${ts}`;
+
+  // ── Get master's head sha ──
+  const refRes = await ghFetch(`/git/ref/heads/master`, token);
+  if (!refRes.ok) return err('Failed to read master ref', 502, origin);
+  const masterSha = (await refRes.json()).object.sha;
+
+  // ── Create branch ──
+  const createRefRes = await ghFetch(`/git/refs`, token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: masterSha }),
+  });
+  if (!createRefRes.ok) {
+    const text = await createRefRes.text();
+    console.error('Branch create failed:', createRefRes.status, text);
+    return err('Failed to create branch', 502, origin);
+  }
+
+  // ── Commit new CSV onto branch ──
+  const putRes = await ghFetch(`/contents/${encodeURIComponent(filename).replace(/%2F/g, '/')}`, token, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message: `data: ${safeCountry} (${safeVariant}) — ${summary.added} added, ${summary.replaced} corrected`,
+      content: btoa(unescape(encodeURIComponent(newCsv))),
+      branch,
+      ...(existing ? { sha: existing.sha } : {}),
+    }),
+  });
+  if (!putRes.ok) {
+    const text = await putRes.text();
+    console.error('Commit failed:', putRes.status, text);
+    return err('Failed to commit CSV', 502, origin);
+  }
+
+  // ── Open PR ──
+  const prBody = buildPrBody({ country: safeCountry, variant: safeVariant, source: safeSource,
+                                author: safeAuthor, summary, rows: safeRows });
+  const prRes = await ghFetch(`/pulls`, token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title: `data: ${safeCountry} (${safeVariant}) — ${summary.added} added, ${summary.replaced} corrected`,
+      head:  branch,
+      base:  'master',
+      body:  prBody,
+    }),
+  });
+  if (!prRes.ok) {
+    const text = await prRes.text();
+    console.error('PR open failed:', prRes.status, text);
+    return err('Failed to open PR', 502, origin);
+  }
+  const pr = await prRes.json();
+
+  return json({ ok: true, pr_url: pr.html_url, pr_number: pr.number, branch, summary }, 201, origin);
+}
+
+// ── CSV upsert ──────────────────────────────────────────────────────────────
+// Returns { newCsv, summary: { added, replaced, replacedDetails: [...] } }.
+// Header semantics: existing header is preserved; new fuel cols are appended
+// to the end (so old rows stay byte-identical, only the touched rows + the
+// header line move).
+
+function upsertRows(existingCsv, variant, source, rows) {
+  // Parse existing
+  let lines = existingCsv ? existingCsv.replace(/\r\n/g, '\n').split('\n') : [];
+  while (lines.length && lines[lines.length - 1] === '') lines.pop();
+  let header;
+  let existingDataLines;
+  if (lines.length === 0) {
+    // Brand new file. Build a sensible default header from the union of the
+    // submitted columns, with the canonical order.
+    const cols = ['period','time_interval','variant','source'];
+    const fuelOrder = ['BEV','PHEV','EREV','HEV','MHEV','PETROL','DIESEL','GAS','CNG','LPG','FLEXFUEL','ETHANOL','OTHERS','TOTAL'];
+    const presentFuels = new Set();
+    for (const r of rows) for (const k of Object.keys(r.fuels)) presentFuels.add(k);
+    for (const f of fuelOrder) if (presentFuels.has(f)) cols.push(f);
+    cols.push('notes');
+    header = cols.join(',');
+    existingDataLines = [];
+  } else {
+    header = lines[0];
+    existingDataLines = lines.slice(1);
+  }
+
+  let cols = header.split(',');
+  // Ensure every submitted fuel column exists; append if missing.
+  const submittedFuels = new Set();
+  for (const r of rows) for (const k of Object.keys(r.fuels)) submittedFuels.add(k);
+  const fuelOrder = ['BEV','PHEV','EREV','HEV','MHEV','PETROL','DIESEL','GAS','CNG','LPG','FLEXFUEL','ETHANOL','OTHERS','TOTAL'];
+  const newFuelCols = [];
+  for (const f of fuelOrder) {
+    if (submittedFuels.has(f) && !cols.includes(f)) newFuelCols.push(f);
+  }
+  if (newFuelCols.length) {
+    // Insert before "notes" if present; else append at end.
+    const notesIdx = cols.indexOf('notes');
+    if (notesIdx >= 0) cols = [...cols.slice(0, notesIdx), ...newFuelCols, ...cols.slice(notesIdx)];
+    else cols = [...cols, ...newFuelCols];
+    header = cols.join(',');
+    // Pad existing lines with empty values for the new columns.
+    existingDataLines = existingDataLines.map(line => padLineForNewCols(line, cols, newFuelCols, notesIdx));
+  }
+
+  const periodIdx  = cols.indexOf('period');
+  const variantIdx = cols.indexOf('variant');
+  if (periodIdx < 0 || variantIdx < 0) {
+    throw new Error('CSV missing period/variant columns');
+  }
+
+  // Build a map keyed by (period, variant) for existing rows we may replace.
+  // Also keep a parallel array of the line text for unchanged passthrough.
+  const replaced = [];
+  const added    = [];
+  const newLines = [];
+  const submittedKeys = new Set(rows.map(r => `${r.period}|${variant}`));
+
+  // Helper to format a fuel value compactly. Integers stay as integers; one
+  // decimal otherwise. NA → empty string.
+  const fmt = v => {
+    if (v === undefined || v === null || v === '') return '';
+    if (Number.isInteger(v)) return String(v);
+    return String(v);
+  };
+
+  for (const dl of existingDataLines) {
+    const parts = dl.split(',');
+    const key = `${parts[periodIdx]}|${parts[variantIdx]}`;
+    if (submittedKeys.has(key)) {
+      // We'll re-emit this row from the submission; capture old value for diff.
+      const old = {};
+      cols.forEach((c, i) => { old[c] = parts[i] ?? ''; });
+      replaced.push({ key, old });
+      continue;
+    }
+    newLines.push(dl);
+  }
+
+  // Build replacement / insert lines from the submission.
+  for (const r of rows) {
+    const key = `${r.period}|${variant}`;
+    const wasReplaced = replaced.some(x => x.key === key);
+    const fields = cols.map(c => {
+      switch (c) {
+        case 'period':        return r.period;
+        case 'time_interval': return r.time_interval;
+        case 'variant':       return variant;
+        case 'source':        return source;
+        case 'notes':         return r.notes || '';
+        default:
+          if (r.fuels[c] !== undefined) return fmt(r.fuels[c]);
+          return '';
+      }
+    });
+    const line = fields.join(',');
+    newLines.push(line);
+    if (!wasReplaced) added.push({ period: r.period });
+  }
+
+  // Sort by period (chronological), keeping yearly/quarterly mixed in by date.
+  newLines.sort((a, b) => {
+    const ap = a.split(',')[periodIdx];
+    const bp = b.split(',')[periodIdx];
+    return ap < bp ? -1 : ap > bp ? 1 : 0;
+  });
+
+  const newCsv = [header, ...newLines].join('\n') + '\n';
+  return {
+    newCsv,
+    summary: {
+      added: added.length,
+      replaced: replaced.length,
+      replacedDetails: replaced,
+    },
+  };
+}
+
+function padLineForNewCols(line, allCols, newCols, notesIdx) {
+  const parts = line.split(',');
+  // The original line was written with the OLD column count. New cols got
+  // inserted before notes (or appended). Reconstruct so values stay aligned.
+  if (notesIdx < 0) {
+    // Appended at end — just push empties.
+    while (parts.length < allCols.length) parts.push('');
+    return parts.join(',');
+  }
+  // Inserted before notes: split parts at original notes position.
+  const oldNotesIdx = notesIdx;       // notes index in OLD cols == same as in NEW cols up to insertion point
+  const before = parts.slice(0, oldNotesIdx);
+  const notesAndAfter = parts.slice(oldNotesIdx);
+  return [...before, ...newCols.map(() => ''), ...notesAndAfter].join(',');
+}
+
+function buildPrBody({ country, variant, source, author, summary, rows }) {
+  const lines = [];
+  lines.push(`Submitted by **${author}** via Submit Data form.`);
+  lines.push('');
+  lines.push(`- **Country:** ${country}`);
+  lines.push(`- **Variant:** ${variant}`);
+  if (source) lines.push(`- **Source:** ${source}`);
+  lines.push(`- **Added:** ${summary.added}`);
+  lines.push(`- **Corrected:** ${summary.replaced}`);
+  lines.push('');
+
+  if (summary.replaced > 0) {
+    lines.push('### Corrections');
+    for (const det of summary.replacedDetails) {
+      const period = det.key.split('|')[0];
+      const submittedRow = rows.find(r => r.period === period);
+      lines.push('');
+      lines.push(`**${period}**`);
+      lines.push('');
+      lines.push('| field | before | after |');
+      lines.push('|---|---|---|');
+      for (const k of Object.keys(submittedRow.fuels)) {
+        const before = det.old[k] ?? '';
+        const after  = String(submittedRow.fuels[k]);
+        if (String(before) !== after) lines.push(`| ${k} | ${before || '_(empty)_'} | ${after} |`);
+      }
+    }
+    lines.push('');
+  }
+
+  if (summary.added > 0) {
+    lines.push('### New rows');
+    for (const r of rows) {
+      const wasReplaced = summary.replacedDetails.some(d => d.key.startsWith(`${r.period}|`));
+      if (wasReplaced) continue;
+      const parts = Object.entries(r.fuels).map(([k, v]) => `${k}=${v}`).join(', ');
+      lines.push(`- **${r.period}** (${r.time_interval}) — ${parts}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push('');
+  lines.push('After merge, trigger the **Render country charts** Action to regenerate plots.');
+  return lines.join('\n');
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,26 +1,21 @@
 name            = "leraffl-gallery-feedback"
 main            = "index.js"
 compatibility_date = "2024-09-23"
-
-# Uncomment and fill in your Cloudflare account ID after running `wrangler login`
-# account_id = "YOUR_ACCOUNT_ID_HERE"
+account_id      = "20d1cbcabbe991286927c4e790c8b528"
 
 [vars]
-# Public, non-secret config — override per environment below if needed
 GITHUB_OWNER = "leraffl"
 GITHUB_REPO  = "leraffl-gallery"
 
-# KV namespace for rate limiting.
-# After deploying, create with:  wrangler kv namespace create RATE_KV
-# Then paste the returned id below and uncomment.
-# [[kv_namespaces]]
-# binding = "RATE_KV"
-# id      = "PASTE_KV_NAMESPACE_ID_HERE"
+# Rate-limit KV namespace (created via `npx wrangler@latest kv namespace create RATE_KV`)
+[[kv_namespaces]]
+binding = "RATE_KV"
+id      = "88b72d5db6444ed2860f0ce5787c0836"
 
-# Secret: GITHUB_TOKEN
-# Do NOT put the token here. Set it with:
-#   wrangler secret put GITHUB_TOKEN
-# (you will be prompted to paste the value)
+# Secret: GITHUB_TOKEN — fine-grained PAT on LeRaffl/LeRaffl-Gallery with
+#   Issues: Read+Write, Contents: Read+Write, Pull requests: Read+Write,
+#   Metadata: Read.
+# Set with: npx wrangler@latest secret put GITHUB_TOKEN
 
 [env.production]
 name = "leraffl-gallery-feedback"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,7 +1,14 @@
-name            = "leraffl-gallery-feedback"
-main            = "index.js"
-compatibility_date = "2024-09-23"
-account_id      = "20d1cbcabbe991286927c4e790c8b528"
+name               = "leraffl-gallery-feedback"
+main               = "index.js"
+compatibility_date = "2026-04-25"
+account_id         = "20d1cbcabbe991286927c4e790c8b528"
+preview_urls       = false
+
+[observability]
+enabled = true
+
+[observability.logs]
+enabled = true
 
 [vars]
 GITHUB_OWNER = "leraffl"
@@ -16,6 +23,3 @@ id      = "88b72d5db6444ed2860f0ce5787c0836"
 #   Issues: Read+Write, Contents: Read+Write, Pull requests: Read+Write,
 #   Metadata: Read.
 # Set with: npx wrangler@latest secret put GITHUB_TOKEN
-
-[env.production]
-name = "leraffl-gallery-feedback"


### PR DESCRIPTION
## What this does

Enables anyone to submit a new monthly data point (or correct an existing one) for a country directly from the page. The submission goes through Cloudflare Worker → opens a PR → you review/merge → the render Action regenerates the four PNGs → page updates.

Same code path handles **new data** and **corrections to old data** — the upsert key is `(period, variant)`. Resubmitting an existing period overwrites it; the PR body shows the before/after for every changed field. Multiple rows ship in a single PR.

## Files

- **`worker/wrangler.toml`** — adds `account_id` and the `RATE_KV` namespace binding (id you got back from `wrangler kv namespace create RATE_KV`).
- **`worker/index.js`** — new `POST /submissions` endpoint (~270 lines added). Validates the payload, reads the current CSV from GitHub, applies row-level upserts, creates a branch, commits, and opens a PR with a human-readable summary.
- **`index.html`** — adds a `Submit Data` tab between FAQ and Feedback. Country dropdown (currently just Germany since only `data/Germany.csv` exists), variant dropdown, source field, multi-row form. Inputs are dynamically built from the country's CSV header — categories that don't exist in that country don't show inputs. Live sum-check warns when categories don't add up to TOTAL. Honeypot included.

## Manual deploy step (you do this once after merge)

After merging this PR, deploy the worker so the new endpoint goes live:

\`\`\`
cd /Users/leraffl/Projects/GitHub/LeRaffl-Gallery/worker
npx wrangler@latest deploy
\`\`\`

The existing `GITHUB_TOKEN` secret is reused (you extended its PAT scopes earlier — no rotation needed).

## Test plan
- [ ] Merge PR.
- [ ] `npx wrangler@latest deploy` in `worker/`.
- [ ] On the deployed page, open Submit Data tab.
- [ ] Submit a March 2026 row with intentionally different numbers ("correction").
- [ ] PR appears in the repo with diff showing before/after for that row.
- [ ] Merge the test PR, manually trigger Render country charts, verify PNG updates with the new numbers.
- [ ] Submit an April 2026 row ("new data").
- [ ] PR appears with row added.
- [ ] Submit a multi-row submission (one new + one correction).
- [ ] PR body lists both correctly.

## Out of scope (future)

- More countries — each needs a `data/<Country>.csv` extracted from the source sheet.
- Variant other than Whole — the worker handles `data/<Country>_<Variant>.csv` already, the UI just hardcodes Whole until more data lands.
- Per-row "delete this period" UI (currently you can only add/correct, not remove a period).
- Captcha — uses honeypot only for now; if spam appears, port the math captcha from feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)