### PR TITLE
docs: architecture handbook in docs/architecture/

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Key files in the repository root:
 | **log_params.R** | Produces and updates the parameter table (`params.csv`). |
 | **images/** | Contains all exported PNG files structured as `images/YYYY-MM/...`. GitHub Pages serves them directly. |
 | **.github/workflows/build-manifest.yml** | CI workflow ensuring that `manifest.json` always stays up to date. |
+| **docs/architecture/** | Architecture handbook — components, data objects, interfaces, flows, secrets, ops. Kept up to date with every PR that changes structure. Start at [docs/architecture/README.md](docs/architecture/README.md). |
 
 ---
 

--- a/docs/architecture/01-overview.md
+++ b/docs/architecture/01-overview.md
@@ -1,0 +1,124 @@
+# 01 · Overview
+
+## What this project is
+
+A public-facing static site at <https://leraffl.github.io/LeRaffl-Gallery/> that publishes monthly extrapolations of the BEV / PHEV / ICE share of new vehicle registrations across ~43 countries, plus four canonical chart types per country, plus interactive tools (Builder, Thresholds, Durations, World Map, Fleet) backed by a model parameter file.
+
+Every chart is the output of a weighted regression on registration data the maintainer collects from national statistics offices. The same parameter set (`params.csv`) drives both the static images and the in-browser interactive tools — there is one source of truth for the model.
+
+## What problems it solves
+
+| For | What |
+|---|---|
+| The maintainer | A reproducible pipeline that turns monthly source data into charts + cross-country comparison tables, with a clear audit trail in Git, and an option to delegate the data-entry step to volunteers without giving anyone push access. |
+| Researchers, journalists, EV-curious public | A single page where you can compare countries on the same scale, read the methodology, see the trajectory and threshold tables, and submit corrections when source data changes. |
+| The maintainer's own Bluesky/X posting workflow | A pre-formatted post text generated from each render that can be copied with one tap on mobile or one click on desktop. |
+
+## Business capabilities
+
+```mermaid
+flowchart TD
+    DC["Data Collection"]
+    MD["Model Derivation<br/>(weighted regression)"]
+    VZ["Visualisation<br/>(4 chart types per country)"]
+    PB["Publication<br/>(static page on Pages)"]
+    CI["Community Interaction<br/>(feedback, Q&A, data corrections)"]
+
+    DC --> MD --> VZ --> PB
+    PB --> CI
+    CI -.-> DC
+```
+
+The capabilities form a clockwise cycle: corrections submitted by the public re-enter Data Collection as Submission PRs.
+
+## Actors
+
+| Actor | Type | Authority |
+|---|---|---|
+| Public visitor | Anonymous human | Read everything, submit feedback issues, submit data corrections (PR-based, requires maintainer merge) |
+| Maintainer (`LeRaffl`) | Authenticated human | Push to master, merge PRs, trigger Actions, hold the GitHub PAT, configure Cloudflare |
+| GitHub Actions runner | Automation | Run R rendering and manifest building, push commits to master with the workflow-scoped token |
+| Cloudflare Worker | Automation | Hold the PAT secret; create issues; open PRs (no direct push) |
+| External data sources | External (KBA, ACEA, Statistik Austria, …) | Provide the source registration data the maintainer transcribes into `data/<Country>.csv` |
+
+## ArchiMate layer view
+
+```mermaid
+flowchart TB
+    subgraph BL["Business Layer"]
+        direction LR
+        A1["Public Visitor"]
+        A2["Maintainer"]
+        BP1["Submit data process"]
+        BP2["Render process"]
+        BP3["Feedback process"]
+        BS1["Visualisation Service"]
+    end
+
+    subgraph AL["Application Layer"]
+        direction LR
+        AC1["Static Page"]
+        AC2["Cloudflare Worker"]
+        AC3["R Render Pipeline"]
+        AC4["Manifest Builder"]
+        AC5["Render-country Action"]
+        AC6["Build-manifest Action"]
+        DO1[("Country CSVs")]
+        DO2[("params.csv / weights.csv")]
+        DO3[("PNG images")]
+        DO4[("manifest.json")]
+        DO5[("posts/*.txt")]
+    end
+
+    subgraph TL["Technology Layer"]
+        direction LR
+        T1["GitHub Pages"]
+        T2["Cloudflare Workers Runtime"]
+        T3["GitHub Actions Runners"]
+        T4["Cloudflare KV"]
+        T5["GitHub REST API"]
+    end
+
+    A1 --> BP1 & BP3
+    A2 --> BP2
+    BP1 -.uses.-> AC1 & AC2
+    BP2 -.uses.-> AC5 & AC3
+    BP3 -.uses.-> AC2
+
+    AC1 -.deployed on.-> T1
+    AC2 -.deployed on.-> T2
+    AC2 -.uses.-> T4 & T5
+    AC5 -.runs on.-> T3
+    AC6 -.runs on.-> T3
+    AC3 -.invoked by.-> AC5
+
+    AC1 --reads--> DO4 & DO5 & DO3
+    AC3 --reads--> DO1
+    AC3 --writes--> DO2 & DO3 & DO5
+    AC4 --reads--> DO3
+    AC4 --writes--> DO4
+```
+
+This is the conceptual layering — Business processes use Application Components; Application Components run on Technology Services. Use this as a navigation aid: if you're thinking about user behaviour go to the Business layer, if you're debugging code go to the Application layer, if you're debugging deploys go to the Technology layer.
+
+## Operating principles (the "why" anchors)
+
+These shape every architectural decision. If a future change conflicts with one of these, that's a discussion to have, not a thing to silently break.
+
+1. **Source-of-truth is Git, not a database.** Every persistent artefact (data, parameters, weights, images, posts, manifest) is a file in the repo. Audit trail = `git log`. No DB to back up, no schema migrations.
+
+2. **Math is sacrosanct.** The weighted regression in `R/fit.R` is byte-identical to the historical Germany script. The current and any historical thresholds (e.g. "BEV reaches 50% in country X by year Y") must remain reproducible from the same input data. Refactors are allowed; numeric drift beyond ~1e-7 relative tolerance is not.
+
+3. **Public submitters never write directly.** Any change to `data/<Country>.csv` from outside the maintainer's machine must go through a PR for review. The Worker has Contents+PRs scopes but is structurally constrained to only ever open PRs, never push to master.
+
+4. **Static-first on the read path.** The page is plain HTML/CSS/JS that fetches static files. No backend on read. The Worker is only on the write path (feedback, submit). This means the page survives any Worker outage in read-only mode.
+
+5. **Renders are reproducible.** Given `data/<Country>.csv` at a point in time, the Render Action produces a deterministic set of PNGs and `params.csv`/`weights.csv` rows. The maintainer's local R workflow produces the same output (modulo the well-understood ~1e-7 optim-convergence drift).
+
+6. **Editor-friendly diffs.** Wide-but-sparse CSVs (one row per period, fuel columns NA when not reported) over Long format, because they're readable in the GitHub diff view. Line-level upserts on `params.csv` so a single-country render only diff-touches its own row.
+
+## See also
+
+- [02-components.md](02-components.md) — what each named box in the diagrams above actually is
+- [05-flows.md](05-flows.md) — sequence diagrams for the user journeys
+- [09-glossary.md](09-glossary.md) — domain jargon

--- a/docs/architecture/01-overview.md
+++ b/docs/architecture/01-overview.md
@@ -48,11 +48,11 @@ flowchart TB
     subgraph BL["Business Layer"]
         direction LR
         A1["Public Visitor"]
-        A2["Maintainer"]
+        A2["Maintainer (LeRaffl)"]
         BP1["Submit data process"]
         BP2["Render process"]
         BP3["Feedback process"]
-        BS1["Visualisation Service"]
+        BP4["Manifest rebuild process"]
     end
 
     subgraph AL["Application Layer"]
@@ -84,6 +84,7 @@ flowchart TB
     BP1 -.uses.-> AC1 & AC2
     BP2 -.uses.-> AC5 & AC3
     BP3 -.uses.-> AC2
+    BP4 -.uses.-> AC6 & AC4
 
     AC1 -.deployed on.-> T1
     AC2 -.deployed on.-> T2
@@ -91,6 +92,7 @@ flowchart TB
     AC5 -.runs on.-> T3
     AC6 -.runs on.-> T3
     AC3 -.invoked by.-> AC5
+    AC4 -.invoked by.-> AC6
 
     AC1 --reads--> DO4 & DO5 & DO3
     AC3 --reads--> DO1
@@ -105,15 +107,18 @@ This is the conceptual layering — Business processes use Application Component
 
 These shape every architectural decision. If a future change conflicts with one of these, that's a discussion to have, not a thing to silently break.
 
-1. **Source-of-truth is Git, not a database.** Every persistent artefact (data, parameters, weights, images, posts, manifest) is a file in the repo. Audit trail = `git log`. No DB to back up, no schema migrations.
+1. **Git is the target source-of-truth.** Every persistent artefact (data, parameters, weights, images, posts, manifest) lives as a file in the repo, audit trail = `git log`, no DB to back up, no schema migrations. *Status today:* the data CSVs are in Git for the 43 listed countries; some upstream collection still flows through external sheets that the maintainer maintains separately. Long-term direction is to retire those and have Git be the only place data ever lives.
 
-2. **Math is sacrosanct.** The weighted regression in `R/fit.R` is byte-identical to the historical Germany script. The current and any historical thresholds (e.g. "BEV reaches 50% in country X by year Y") must remain reproducible from the same input data. Refactors are allowed; numeric drift beyond ~1e-7 relative tolerance is not.
+2. **The model has history; treat it accordingly.** The weighted regression in `R/fit.R` was developed iteratively; the most influential countries during assumption-setting were Germany, Austria, the Nordics, and Ireland. Two operational consequences:
+   - *Numeric drift is expected and bounded.* Refits across machines / R builds drift at the ~1e-7 relative tolerance level due to optim convergence and BLAS differences. Anything beyond that means the math has changed and historical thresholds become non-reproducible — that's a code-review-stop.
+   - *The grey/coloured band around each curve is not a true confidence interval (yet).* It's a visual range derived from the fit's standard error, useful for "this is roughly where the uncertainty sits" but not statistically rigorous. A proper CI is a future improvement.
+   - For an engineer touching `R/fit.R`: the math implementation is intentionally a near byte-copy of the historical script. Restructure freely, but do not change the formula or the optimiser without coordinating with the maintainer.
 
-3. **Public submitters never write directly.** Any change to `data/<Country>.csv` from outside the maintainer's machine must go through a PR for review. The Worker has Contents+PRs scopes but is structurally constrained to only ever open PRs, never push to master.
+3. **Public submitters never write directly.** Any change to `data/<Country>.csv` from outside the maintainer's machine goes through a PR for review. The Worker has Contents+PRs scopes but is structurally constrained to only ever open PRs, never push to master.
 
 4. **Static-first on the read path.** The page is plain HTML/CSS/JS that fetches static files. No backend on read. The Worker is only on the write path (feedback, submit). This means the page survives any Worker outage in read-only mode.
 
-5. **Renders are reproducible.** Given `data/<Country>.csv` at a point in time, the Render Action produces a deterministic set of PNGs and `params.csv`/`weights.csv` rows. The maintainer's local R workflow produces the same output (modulo the well-understood ~1e-7 optim-convergence drift).
+5. **Renders are reproducible.** Given `data/<Country>.csv` at a point in time, the Render Action produces a deterministic set of PNGs and `params.csv`/`weights.csv` rows, modulo the bounded ~1e-7 drift in principle 2.
 
 6. **Editor-friendly diffs.** Wide-but-sparse CSVs (one row per period, fuel columns NA when not reported) over Long format, because they're readable in the GitHub diff view. Line-level upserts on `params.csv` so a single-country render only diff-touches its own row.
 

--- a/docs/architecture/02-components.md
+++ b/docs/architecture/02-components.md
@@ -30,6 +30,8 @@ flowchart TB
         REPO["Repo: data/, posts/, images/, params.csv, weights.csv, manifest.json"]
     end
 
+    Maintainer((Maintainer))
+
     SP -.served by.-> GP
     SP -- POST --> WK
     WK -- REST --> REPO
@@ -38,8 +40,8 @@ flowchart TB
     RA -- commits --> REPO
     BA -- commits --> REPO
     LR -- commits --> REPO
-    REPO -- triggers --> RA
-    REPO -- triggers --> BA
+    Maintainer -- manual dispatch --> RA
+    REPO -- "push to images/**" --> BA
     REPO -- auto-deploy --> GP
 ```
 

--- a/docs/architecture/02-components.md
+++ b/docs/architecture/02-components.md
@@ -1,0 +1,269 @@
+# 02 · Components
+
+This is the application inventory. For each component: what it is, where it lives, what it depends on, why it exists in this shape (rationale).
+
+## Component map
+
+```mermaid
+flowchart TB
+    subgraph Frontend["Frontend (browser)"]
+        SP["Static Page<br/>index.html"]
+    end
+
+    subgraph Edge["Cloudflare Edge"]
+        WK["Cloudflare Worker<br/>worker/index.js"]
+    end
+
+    subgraph CI["GitHub Actions"]
+        RA["Render-country Action<br/>.github/workflows/render-country.yml"]
+        BA["Build-manifest Action<br/>.github/workflows/build-manifest.yml"]
+    end
+
+    subgraph R["R Code"]
+        RP["Render Pipeline<br/>R/render_country.R + data/fit/plots/upsert/post_text"]
+        MB["Manifest Builder<br/>build_manifest.R"]
+        LR["Legacy Local R<br/>bev_share_*.R (off-repo, on maintainer's Mac)"]
+    end
+
+    subgraph Host["GitHub Hosting"]
+        GP["GitHub Pages"]
+        REPO["Repo: data/, posts/, images/, params.csv, weights.csv, manifest.json"]
+    end
+
+    SP -.served by.-> GP
+    SP -- POST --> WK
+    WK -- REST --> REPO
+    RA -- invokes --> RP
+    BA -- invokes --> MB
+    RA -- commits --> REPO
+    BA -- commits --> REPO
+    LR -- commits --> REPO
+    REPO -- triggers --> RA
+    REPO -- triggers --> BA
+    REPO -- auto-deploy --> GP
+```
+
+---
+
+## 2.1 Static Page (`index.html`)
+
+### What it is
+
+A single ~6000-line HTML file with inline CSS and inline JavaScript. No build step, no framework, no transpiler. Served verbatim from `master:index.html` by GitHub Pages.
+
+### Tabs
+
+| Tab | Source of data | What it shows |
+|---|---|---|
+| Gallery | `manifest.json` + `images/<period>/<slug>_*.png` | Grid of all PNGs filterable by country, type, period |
+| Thresholds | `params.csv` | When each country reaches 20%/50%/80% BEV under the current model |
+| Durations | `params.csv` | How many years each country needs to traverse 20→80% |
+| Builder | `params.csv` | Interactive "what-if" curves with adjustable v1/v2/t0 |
+| Fleet | `fleet/*.csv`, `fleet_meta.json` | Bestand projection (separate from new-registrations data) |
+| World Map | `params.csv` + `weights.csv` | Choropleth of current BEV share |
+| FAQ | inline `FAQ_DATA` array | Searchable Q&A |
+| Submit Data | Worker `POST /submissions` | Form for new monthly data points + corrections |
+| Feedback & Questions | Worker `GET/POST /issues` | Public discussion thread mirrored from GitHub Issues |
+
+### Notable in-page features
+
+- **Copy-post button** on every Gallery card: fetches `posts/<slug>.txt` and writes to clipboard
+- **FAB** (floating action button) bottom-right: opens the feedback modal from any tab with the current tab's filters captured as context
+- **Math captcha** on feedback submit (3 + 4 = ?), **honeypot** on both feedback and submit
+- **Lightbox** on chart click → larger image + Download link
+
+### Why a single file with no build?
+
+- The maintainer runs the project solo and wants to be able to edit the page in any text editor without setting up Node/Webpack/etc.
+- GitHub Pages serves it as-is. No CI build required for the read path.
+- LLMs and AI agents can read the entire UI in one pass.
+- Trade-off accepted: harder to organise, no component reuse, no type safety.
+
+---
+
+## 2.2 Cloudflare Worker (`worker/index.js`)
+
+### What it is
+
+A ~600-line JavaScript module deployed to Cloudflare's V8-isolate runtime. The single bridge between the read-only static page and the write-side of GitHub.
+
+### Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET`  | `/issues` | List feedback issues (cached 60 s) |
+| `POST` | `/issues` | Create a feedback issue |
+| `POST` | `/submissions` | Open a PR with one or more upserted rows in `data/<Country>.csv` |
+| `OPTIONS` | * | CORS preflight |
+
+Full contracts → [04-interfaces.md](04-interfaces.md).
+
+### What's in the env
+
+- `GITHUB_TOKEN` (secret) — fine-grained PAT with Issues R/W, Contents R/W, Pull requests R/W, Metadata R, scoped to this repo
+- `RATE_KV` (binding) — Cloudflare KV namespace used as a per-IP counter with 1-hour TTL
+- `GITHUB_OWNER`, `GITHUB_REPO` (vars) — non-secret config
+
+### Why a Worker and not Lambdas / Vercel functions / a tiny VPS?
+
+- Cloudflare Workers free tier covers our load comfortably (we'd need >100k requests/day to leave it)
+- Cold-start time is essentially zero (V8 isolates, not containers), so the page never feels slow
+- The same Worker now hosts Feedback **and** Submit — adding new write endpoints is just another route, no new infrastructure
+- Trade-off accepted: limited runtime API (no Node `fs`, no native modules), but everything we do is HTTP fetches so this is a fit
+
+---
+
+## 2.3 R Render Pipeline (`R/`)
+
+### What it is
+
+A set of small, focused R modules that turn `data/<Country>.csv` into the four canonical PNGs for that country, plus a `params.csv` row, a `weights.csv` row, and a `posts/<slug>.txt` social-media text.
+
+### Files
+
+| File | Responsibility | Shape |
+|---|---|---|
+| `R/data.R` | CSV loader, share derivations, TTM (rolling-12-month) aggregation | `load_country_csv(path)`, `compute_ttm_long(df)` |
+| `R/fit.R` | Weighted regression with full time-history loop | `fit_history(df, extrapol = 2200, confidence_level = 0.999)` |
+| `R/plots.R` | The four ggplot2 plot constructors | `plot_bev_trajectory`, `plot_ice_bev_phev`, `plot_timer`, `plot_ttm_shares` |
+| `R/upsert.R` | Line-level upsert into `params.csv` and `weights.csv` | `upsert_params`, `upsert_weights`, `data_per_from_df`, `compute_weight` |
+| `R/post_text.R` | Build the social-media post text per country | `build_post_text(df, country, last_period = NULL)` |
+| `R/render_country.R` | Entry point: orchestrates everything | `Rscript R/render_country.R <Country> [<Variant>]` |
+
+### Key invariants
+
+- `R/fit.R::fit_history` is **byte-for-byte the historical Germany script's regression code**, only renamed for country-agnostic use. Do not change the math without coordinating with the maintainer; threshold reproducibility for old runs depends on it.
+- `R/data.R::compute_ttm_long` only emits a row when **every present fuel column** has a complete 12-month non-NA window. This is what makes the TTM stack hit 100% from the very first plotted period.
+- `R/upsert.R::upsert_params` writes line-level — only the touched country/variant row changes. Previous attempts that round-tripped the whole CSV through `read.csv`/`write.table` caused noisy reformatting (scientific → decimal, trailing zero changes) and were reverted.
+
+### Why split into so many files?
+
+- The original Germany R script was 1360 lines mixing IO, math, plotting, Git operations, and Google Sheets. It was unreadable.
+- Splitting by responsibility lets each module have a contract that's testable in isolation. `fit.R` doesn't know about plots; `plots.R` doesn't know about CSVs; `render_country.R` is the only orchestrator.
+- The math file is now small enough to audit in one screen, which is essential because of invariant #1 above.
+
+---
+
+## 2.4 Manifest Builder (`build_manifest.R`)
+
+### What it is
+
+An R script that scans `images/` and writes `manifest.json`. The manifest is what the Static Page's Gallery tab fetches at load.
+
+### Inputs and outputs
+
+```
+INPUT:  images/<YYYY-MM>/<slug>_<type>_<YYYYMMDD>.png   (recursively)
+OUTPUT: manifest.json   (top-level, committed to repo)
+```
+
+`manifest.json` shape:
+
+```json
+{
+  "updated": "2026-05-08",
+  "images": [
+    {
+      "country": "Germany",
+      "country_slug": "germany",
+      "type": "ICE_BEV",
+      "period": "2026-04",
+      "date": "2026-05-08",
+      "filename": "germany_ICE_BEV_20260508.png",
+      "url": "images/2026-04/germany_ICE_BEV_20260508.png",
+      "alt": "Germany ICE-BEV-Hybrid trajectory"
+    }
+  ]
+}
+```
+
+### Why a separate manifest instead of letting the page list directories?
+
+- GitHub Pages does not support directory listings. The page would have to either (a) hardcode every filename or (b) hit a backend.
+- Pre-computing the manifest at push-time is free, fast, and lets the page stay completely static.
+
+---
+
+## 2.5 Render-country Action (`.github/workflows/render-country.yml`)
+
+### What it is
+
+A GitHub Action with `workflow_dispatch` only — it runs only when manually triggered from the Actions UI with `country` and `variant` inputs.
+
+### What it does
+
+1. Checks out the repo
+2. Sets up R via `r-lib/actions/setup-r`
+3. Installs the R package set (ggplot2, scales, grid, png, ggtext, viridis, showtext, sysfonts, glue) with apt prebuilds
+4. Runs `Rscript R/render_country.R <country> <variant>`
+5. Commits the resulting `images/<period>/*.png`, `params.csv` row update, `weights.csv` row update, `posts/<slug>.txt`, `posts/<slug>_<period>.txt` via `EndBug/add-and-commit`
+
+### Why manual trigger only and not on `data/` push?
+
+Submission PRs typically batch multiple corrections in one merge. Auto-rendering on every `data/` push would re-render before the maintainer's review of the merge result. Manual trigger keeps the maintainer in the loop and lets them choose which country to refresh.
+
+---
+
+## 2.6 Build-manifest Action (`.github/workflows/build-manifest.yml`)
+
+### What it is
+
+A GitHub Action that rebuilds `manifest.json` whenever PNG files change.
+
+### Triggers
+
+- Push to `images/**` (any new/deleted/renamed image)
+- Push to `build_manifest.R` (the builder itself changed)
+- Daily cron at 03:17 UTC as a self-healing fallback
+- Manual dispatch
+
+### Why the cron?
+
+Defensive — if a manual upload bypasses the Render action (legacy local R workflow), the cron still picks it up within a day.
+
+---
+
+## 2.7 GitHub Pages
+
+### What it is
+
+A built-in GitHub feature that serves `master:/index.html` (and any referenced static asset) at `https://leraffl.github.io/LeRaffl-Gallery/`. Configured in repo Settings → Pages.
+
+### What it serves
+
+The entire repo content is technically reachable, but the page only references:
+- `index.html` (entry)
+- `manifest.json`
+- `params.csv`, `weights.csv`
+- `images/<period>/*.png`
+- `posts/<slug>.txt`
+- `fleet/*.csv`, `fleet/fleet_meta.json`
+
+### Caching
+
+GitHub Pages serves with default `Cache-Control: max-age=600`. The page uses `cache: 'no-store'` on critical fetches (manifest, posts) so corrections appear fast.
+
+---
+
+## 2.8 Legacy Local R Pipeline
+
+### What it is
+
+Per-country R scripts on the maintainer's Mac (`bev_share_<Country>_*.R`) that read directly from a Google Sheet and push images + params + weights to the repo. Off-repo; not part of CI.
+
+### Status
+
+Still functional and the maintainer's preferred path for fast iteration during data-collection. Output is byte-compatible with the new pipeline — same image filenames, same `params.csv` row format.
+
+### Why keep it instead of migrating fully to the new pipeline?
+
+- The maintainer can iterate in RStudio with breakpoints, `View(df)`, etc. — far faster than triggering CI.
+- Google Sheets is still where the maintainer transcribes raw national data; until that flow moves to direct CSV editing, the local R is the bridge.
+- The new pipeline is the **authoritative** path (used by the Render Action and any public submission). The local R is the **convenience** path. Both write the same files; whichever wins last wins.
+
+## See also
+
+- [03-data-objects.md](03-data-objects.md) — what each component reads/writes
+- [04-interfaces.md](04-interfaces.md) — Worker endpoint contracts
+- [05-flows.md](05-flows.md) — how the components dance together for each user journey
+- [08-deploy-ops.md](08-deploy-ops.md) — how to deploy/trigger each component

--- a/docs/architecture/03-data-objects.md
+++ b/docs/architecture/03-data-objects.md
@@ -1,0 +1,342 @@
+# 03 · Data Objects
+
+Every persistent piece of data in the system, in one place. Schema, owner, lifecycle, intentional design choices.
+
+## Inventory at a glance
+
+```mermaid
+flowchart LR
+    subgraph SoT["Source of Truth"]
+        D1["data/&lt;Country&gt;.csv<br/>(raw registrations)"]
+    end
+
+    subgraph Derived["Derived (regenerated from data/)"]
+        D2["params.csv<br/>(model parameters)"]
+        D3["weights.csv<br/>(TTM totals)"]
+        D4["images/&lt;period&gt;/*.png<br/>(four charts × country)"]
+        D5["posts/&lt;slug&gt;.txt<br/>posts/&lt;slug&gt;_&lt;period&gt;.txt<br/>(post text)"]
+        D6["manifest.json<br/>(image index)"]
+    end
+
+    subgraph Independent["Independent datasets"]
+        D7["fleet/*.csv<br/>fleet/fleet_meta.json"]
+        D8["assets/flags/*.png<br/>assets/fonts/*.otf<br/>assets/variant/*.png"]
+    end
+
+    subgraph Ephemeral["Non-Git state"]
+        D9[("Cloudflare KV<br/>rate-limit counters")]
+        D10[("GitHub Issues<br/>(feedback)")]
+        D11[("GitHub PRs<br/>(submissions)")]
+    end
+
+    D1 --> D2 & D3 & D4 & D5
+    D4 --> D6
+```
+
+## 3.1 Country Raw Data
+
+### Where
+
+`data/<Country>.csv` for variant "Whole" (the default).
+`data/<Country>_<Variant>.csv` for non-Whole variants (planned, not yet active).
+
+Examples: `data/Germany.csv`, `data/Türkiye.csv`, `data/New Zealand.csv`.
+
+### Schema
+
+CSV with header. **Wide-but-sparse**: per-country only the fuel columns that the source actually reports.
+
+| Column | Required | Type | Notes |
+|---|---|---|---|
+| `period` | yes | `YYYY-MM` | Month-resolution. Quarterly rows use the middle month (Q1→Feb, Q2→May, Q3→Aug, Q4→Nov). Yearly rows use July (`YYYY-07`). |
+| `time_interval` | yes | `monthly` \| `quarterly` \| `yearly` | Drives the post-text "TTM" computation and the chart x-axis treatment. |
+| `variant` | yes | string | Always `Whole` for top-level country files. Reserved for future per-CSV variants. |
+| `source` | yes | string | URL or short name (`KBA`, `Statistik Austria`). Carried per-row so the maintainer can audit which row came from where. |
+| `BEV` | yes | numeric | Battery electric vehicles registered in the period. |
+| `PHEV` | optional | numeric | Plug-in hybrid. Absent in Türkiye, Georgia. |
+| `EREV` | optional | numeric | Extended-range EVs (subset of PHEV in some sources). Currently only China. |
+| `HEV` | optional | numeric | Full hybrid. For countries that report a single "Hybrid" total without splitting (Türkiye, Georgia), this column carries the total and the post-text labels it as "Hybrid". |
+| `MHEV` | optional | numeric | Mild hybrid. Reserved; not currently in any active CSV. |
+| `PETROL` | optional | numeric | Pure-petrol ICE. |
+| `DIESEL` | optional | numeric | Pure-diesel ICE. |
+| `GAS`, `CNG`, `LPG` | optional | numeric | Reserved for sources that split natural-gas variants. |
+| `FLEXFUEL` | optional | numeric | Brazil, Sweden. |
+| `ETHANOL` | optional | numeric | Reserved. |
+| `OTHERS` | optional | numeric | Catch-all bucket. |
+| `ICE` | optional | numeric | Reported when source gives a single ICE total without petrol/diesel breakdown (China, USA, South Korea, Thailand, Chile). |
+| `TOTAL` | yes | numeric | Sum of everything for the period. |
+| `notes` | optional | string | Free text for the submitter or maintainer. |
+
+### Owner / lifecycle
+
+- **Author**: Maintainer (when transcribing from source) or Public Visitor (via Submit Data form, then merged after review).
+- **Created**: Per-country, when the country is added to the project.
+- **Updated**: When a new period arrives or when older data is corrected upstream. Upserts are keyed on `(period, variant)`.
+- **Deleted**: Never expected. Deleting a row would make the historical chart incomprehensible.
+
+### Why wide-but-sparse and not long format?
+
+- Diff readability: a corrected April row in Wide format is one CSV line edit. In Long format it would be 5–8 separate rows changing.
+- Editor-friendliness: spreadsheet apps open Wide naturally. Long needs a pivot to read.
+- Schema flexibility: adding a new fuel category for one country is a new column; old rows stay byte-identical because empty cells are valid.
+
+### Why one file per country and not one mega-CSV?
+
+- PR diffs only touch one country at a time.
+- Different countries have different categorical schemas; one big CSV would either be 20+ columns wide or split into smaller subsets.
+- Performance is irrelevant at this scale (largest country = ~250 rows). Discoverability and diffability win.
+
+### Country-specific column mappings (applied at extraction)
+
+Some sources use non-canonical column names. The Excel→CSV extraction normalises:
+
+| Source column | Canonical column | Country |
+|---|---|---|
+| `OTHER` | `OTHERS` | Malta |
+| `HYBRIDS` | `HEV` | Türkiye (single hybrid bucket) |
+| `Hybrid` | `HEV` | Georgia (single hybrid bucket) |
+| `PETROL-GAS` | `PETROL` | Georgia (treated as ICE/petrol per maintainer convention) |
+
+---
+
+## 3.2 Model Parameters
+
+### Where
+
+`params.csv` (top-level).
+
+### Schema
+
+```csv
+country,variant,v1,v2,t0,data_per,model_date,source,baseline_date,ice_v1,ice_v2,ice_t0
+Germany,Whole,-1.050261627753e-4,2.898020288277,2011,2026-04,2026-05-08,KBA,,-3.461242394113e-4,2.637247479199,2011
+```
+
+| Column | Meaning |
+|---|---|
+| `country, variant` | Composite key |
+| `v1, v2, t0` | BEV-curve regression parameters: `share(t) = 1 - exp(v1 * (t - (t0-1))^v2)` |
+| `ice_v1, ice_v2, ice_t0` | ICE-curve regression parameters (analogous form) |
+| `data_per` | Latest data period this fit was based on (`YYYY-MM`) |
+| `model_date` | When the fit was last run (`YYYY-MM-DD`) |
+| `source` | Mirror of the raw-data source for display purposes |
+| `baseline_date` | Reserved (always blank currently) |
+
+### Owner / lifecycle
+
+- **Author**: R Render Pipeline (`R/upsert.R::upsert_params`) on every render.
+- **Updated**: Line-level — only the touched `(country, variant)` row changes. The rest of the file stays byte-identical.
+- **Read by**: The Static Page for Builder, Thresholds, Durations, World Map tabs.
+
+### Number formatting convention
+
+- Scientific notation when `|x| < 1e-3` (e.g. `-1.050261627753e-4`)
+- Decimal otherwise (e.g. `2.898020288277`)
+- Exponents use the historical `e-4` style, not `e-04`
+
+This matches what the maintainer's local R script produces, so PR diffs from local-R pushes and from the Render Action look the same.
+
+---
+
+## 3.3 Aggregate Weights
+
+### Where
+
+`weights.csv` (top-level).
+
+### Schema
+
+```csv
+country,variant,weight,data_per,model_date
+Germany,Whole,2892424,2026-04,2026-05-08
+```
+
+`weight` = trailing 12-month sum of `TOTAL` for monthly countries; trailing 4 quarters for quarterly; the latest year's value for yearly. Used by the World Map tab to weight the country choropleth and by aggregate "EU/world" computations.
+
+### Owner / lifecycle
+
+Same as params.csv — rewritten line-level by `R/upsert.R::upsert_weights` on each render.
+
+---
+
+## 3.4 Chart Images
+
+### Where
+
+`images/<YYYY-MM>/<slug>[_<type>]_<YYYYMMDD>.png`
+
+- `<YYYY-MM>` = the period the data is from (e.g. `2026-04`)
+- `<slug>` = the lower-cased country, with non-alphanumerics replaced by `_` (`germany`, `new_zealand`, `türkiye`)
+- `<type>` ∈ {`ICE_BEV`, `time`, `ttm_shares`} or absent for the BEV trajectory
+- `<YYYYMMDD>` = the day the chart was rendered (the model_date, in compact form)
+
+### Four chart types per country
+
+| Type suffix | What it shows | Dimensions |
+|---|---|---|
+| (no suffix) | BEV-share trajectory, BEV vs all alternatives, with quartile-coloured points | 3840×2160 px |
+| `_ICE_BEV` | Combined ICE/BEV/PHEV trajectories with confidence ribbons | 12.8×7.2 in @ 300 dpi |
+| `_time` | Timer plot — how the "years to 80% BEV" expectation evolved over time | 12.8×7.2 in @ 300 dpi |
+| `_ttm_shares` | Stacked trailing-12-month bar plot per fuel type | 12.8×7.2 in @ 300 dpi |
+
+### Owner / lifecycle
+
+- **Author**: R Render Pipeline (via the Action) or Legacy Local R (via the maintainer's Mac).
+- **Created**: One quartet per render run. Old PNGs from previous run-days stay in the `images/<period>/` folder as historical record (you can `git log` them to see how the curve shifted).
+- **Read by**: GitHub Pages (the Gallery), externally embedded by anyone who links to a chart.
+
+### Why include the render-day in the filename?
+
+Two renders of the same country in the same period (e.g. data was corrected on day 5, re-rendered on day 8) produce two distinct files. This way:
+- The page's gallery view sees both
+- Old links from social-media posts don't 404
+- `git log` shows when each version was rendered
+
+---
+
+## 3.5 Image Manifest
+
+### Where
+
+`manifest.json` (top-level).
+
+### Owner / lifecycle
+
+Written by the Build-manifest Action (`build_manifest.R`) on push to `images/**` or on its daily cron. Read by the Static Page on every load.
+
+### Schema
+
+See [02-components.md § 2.4](02-components.md). Top-level `{updated, images: [{country, country_slug, type, period, date, filename, url, alt}, …]}`.
+
+---
+
+## 3.6 Posts
+
+### Where
+
+- `posts/<slug>.txt` — the **latest** post text per country, overwritten on each render. **This is what the Copy-post button and Apple Shortcut fetch.**
+- `posts/<slug>_<period>.txt` — historical archive, one file per render. Never overwritten; pile up for as long as the country exists.
+
+### Schema
+
+Plain UTF-8 text, ~10 lines, one country flag emoji at the top, BEV/PHEV/ICE breakdown for the latest period, then trailing-12-months breakdown, then a link to the gallery. Format matches what the historical Germany R script produced for posting on Bluesky/X.
+
+### Why two files per render?
+
+- `<slug>.txt` is the stable URL. Shortcuts and the page link to a fixed address. New render → file content changes, URL unchanged.
+- `<slug>_<period>.txt` is the audit trail. If you want to re-post an old month or audit how the text evolved, the file with that period in its name is right there.
+
+### Why generate at render-time and not on-demand in the page?
+
+- The percentages depend on the data at the moment of render, not the moment of viewing. Lock them in.
+- Shortcuts (raw URL fetch) need a static endpoint, not a JS-computed string.
+- Computing in-page would duplicate the logic in JS and risk drift from the R version.
+
+---
+
+## 3.7 Fleet Dataset
+
+### Where
+
+`fleet/fleet_initial.csv`, `fleet/fleet_observed.csv`, `fleet/fleet_meta.json`, `fleet/hazard_defaults.csv`.
+
+### What it is
+
+A **separate** dataset and model — vehicle fleet (Bestand) projections, not new-registrations. Driven by a hazard-rate retirement model. Has its own tab in the static page.
+
+### Why separate from the main pipeline?
+
+Different units (stock vs flow), different time-resolution (year-of-vintage cohorts), different model (hazard rates, not weighted regression). Forcing it into the same files as `data/<Country>.csv` would just confuse both.
+
+### Owner / lifecycle
+
+Maintainer-curated. No public submit path yet. No automatic render — fleet visualisations are computed in-browser from the static CSVs.
+
+---
+
+## 3.8 Assets
+
+### Where
+
+- `assets/flags/<slug>.png` — one per country/variant, used as a watermark in the corner of charts
+- `assets/fonts/fontawesome/otfs/*.otf` + `icomoon.ttf` — used for the social-media icons in chart captions
+- `assets/variant/{ldv,hdv,bus}.png` — symbol overlays for variant slices
+
+### Lifecycle
+
+Static. New flags added when a new country joins. Font files immutable.
+
+### Why bundle FontAwesome OTFs in the repo instead of CDN?
+
+The R-render runs in a CI sandbox without internet for asset fetches (and even if it could, it would be brittle). Bundling the OTFs (~1.7 MB) makes renders deterministic and offline-capable.
+
+### Why no SVGs / metadata of FontAwesome?
+
+The maintainer originally bundled the full FA distribution (~24 MB). Only the OTFs are referenced by `showtext` for caption rendering. SVG and metadata files were trimmed in the initial repo-import.
+
+---
+
+## 3.9 Feedback Issues
+
+### Where
+
+GitHub Issues with label `feedback`. Not files in the repo.
+
+### Lifecycle
+
+- Created via Worker `POST /issues` from the Feedback tab modal
+- Labelled with `feedback` + `feedback:<category>` (where category is one of `question`, `bug`, `idea`, `data`, `comment`)
+- Maintainer can reply on GitHub; replies show up in the page's Feedback tab as comments
+- Status derived from issue state: open → "open"; closed → "resolved"; commented by maintainer → "answered"
+- Hidden by adding the `hidden` label; pinned by adding `pinned`
+
+### Why issues and not a separate database?
+
+Free, integrated with maintainer's existing GitHub workflow, no extra moderation tooling, native push notifications via the GitHub mobile app.
+
+---
+
+## 3.10 Submission PRs
+
+### Where
+
+GitHub Pull Requests. Branch name `submit/<country>-<variant>-<YYYYMMDDHHMMSS>`.
+
+### Lifecycle
+
+- Created by Worker `POST /submissions` after validating the payload and applying the upsert in-memory
+- Diff is exactly one file: the affected `data/<Country>.csv` (or new file if first ever submission for that country)
+- PR body lists added rows and corrected rows with before/after values
+- Maintainer reviews → merges → manually triggers Render Action
+
+### Why PR-based and not a moderation queue?
+
+Re-uses GitHub's review UI (rich diff, line comments, mobile app). Zero new infrastructure. Audit trail is the standard PR record. Roll-back is `git revert`.
+
+---
+
+## 3.11 Rate-Limit Counters
+
+### Where
+
+Cloudflare KV namespace `RATE_KV`. Keys:
+- `rl:<ip>` — feedback submissions counter
+- `sub:<ip>` — data-submission counter
+
+### Schema
+
+Value = ASCII integer count. TTL = 3600 s.
+
+### Why two separate counters?
+
+A user submitting many corrections shouldn't lock themselves out of asking a question, and vice-versa. Different counters keep the two flows independent.
+
+### Why KV and not Durable Objects / a database?
+
+Counter granularity is per-IP-per-hour, eventual consistency is fine. KV is the cheapest, simplest option. We never read the counter outside the per-request rate-check.
+
+## See also
+
+- [04-interfaces.md](04-interfaces.md) — exactly how the Worker reads/writes these
+- [05-flows.md](05-flows.md) — when each object is created/updated in the user journeys
+- [09-glossary.md](09-glossary.md) — term definitions for `slug`, `period`, `TTM`, etc.

--- a/docs/architecture/03-data-objects.md
+++ b/docs/architecture/03-data-objects.md
@@ -56,13 +56,13 @@ CSV with header. **Wide-but-sparse**: per-country only the fuel columns that the
 | `PHEV` | optional | numeric | Plug-in hybrid. Absent in Türkiye, Georgia. |
 | `EREV` | optional | numeric | Extended-range EVs (subset of PHEV in some sources). Currently only China. |
 | `HEV` | optional | numeric | Full hybrid. For countries that report a single "Hybrid" total without splitting (Türkiye, Georgia), this column carries the total and the post-text labels it as "Hybrid". |
-| `MHEV` | optional | numeric | Mild hybrid. Reserved; not currently in any active CSV. |
-| `PETROL` | optional | numeric | Pure-petrol ICE. |
-| `DIESEL` | optional | numeric | Pure-diesel ICE. |
-| `GAS`, `CNG`, `LPG` | optional | numeric | Reserved for sources that split natural-gas variants. |
-| `FLEXFUEL` | optional | numeric | Brazil, Sweden. |
-| `ETHANOL` | optional | numeric | Reserved. |
-| `OTHERS` | optional | numeric | Catch-all bucket. |
+| `MHEV` | optional | numeric | Mild hybrid. Reserved; not currently in any active CSV. Treated as a subset of HEV (which is a subset of ICE) in every output chart. |
+| `PETROL` | optional | numeric | Conceptually pure-petrol ICE. *Caveat:* a small number of source statistics today fold petrol-HEV variants into this column rather than the HEV column. Improving the upstream split is a known data-quality task; for now the headline ICE/BEV/PHEV trajectory is unaffected because all of it ends up in the ICE bucket either way. |
+| `DIESEL` | optional | numeric | Conceptually pure-diesel ICE. Same caveat as `PETROL` — a few sources fold diesel-HEV here. |
+| `GAS`, `CNG`, `LPG` | optional | numeric | Reserved for sources that split natural-gas variants. In practice most countries' source data folds these into `OTHERS`. Always counted as ICE in the output charts. |
+| `FLEXFUEL` | optional | numeric | Country-specific (Brazil-relevant; some Sweden rows). Counted as ICE in the output charts. |
+| `ETHANOL` | optional | numeric | Reserved; mostly seen folded into `OTHERS` upstream. ICE in the output charts. |
+| `OTHERS` | optional | numeric | Catch-all bucket — typically absorbs `GAS`/`CNG`/`LPG`/`ETHANOL` when the source doesn't split them. ICE in the output charts. |
 | `ICE` | optional | numeric | Reported when source gives a single ICE total without petrol/diesel breakdown (China, USA, South Korea, Thailand, Chile). |
 | `TOTAL` | yes | numeric | Sum of everything for the period. |
 | `notes` | optional | string | Free text for the submitter or maintainer. |
@@ -242,7 +242,7 @@ Plain UTF-8 text, ~10 lines, one country flag emoji at the top, BEV/PHEV/ICE bre
 
 ### What it is
 
-A **separate** dataset and model — vehicle fleet (Bestand) projections, not new-registrations. Driven by a hazard-rate retirement model. Has its own tab in the static page.
+A **separate** dataset and model — vehicle fleet (stock) projections, not new-registrations. Driven by a hazard-rate retirement model. Has its own tab in the static page.
 
 ### Why separate from the main pipeline?
 

--- a/docs/architecture/04-interfaces.md
+++ b/docs/architecture/04-interfaces.md
@@ -1,0 +1,296 @@
+# 04 · Interfaces
+
+Wire-level contracts. If something on this page changes (request shape, response shape, status codes, validation rules), update it the same PR.
+
+## Interface map
+
+```mermaid
+flowchart LR
+    Browser --> WG["Worker GET /issues"]
+    Browser --> WP1["Worker POST /issues"]
+    Browser --> WP2["Worker POST /submissions"]
+    Browser --> Raw["GitHub raw.githubusercontent.com"]
+    Browser --> Pages["GitHub Pages static fetch"]
+
+    Worker --> GHI["GitHub Issues API"]
+    Worker --> GHC["GitHub Contents API"]
+    Worker --> GHR["GitHub Git Refs API"]
+    Worker --> GHP["GitHub Pulls API"]
+    Worker --> KV["Cloudflare KV"]
+
+    Action --> Repo["GitHub Repo (push)"]
+    Action --> RPM["Posit Public Package Manager (R packages)"]
+```
+
+---
+
+## 4.1 Worker GET /issues
+
+### Purpose
+
+Return all visible feedback issues with their comments, mapped into the page's expected shape.
+
+### Request
+
+```
+GET /issues
+Headers:
+  Origin: https://leraffl.github.io
+```
+
+### Response 200
+
+```json
+{
+  "updated": "2026-05-08T12:34:56.789Z",
+  "issues": [
+    {
+      "number": 42,
+      "title": "Belgium March data looks off",
+      "body": "...",
+      "category": "data",
+      "status": "open" | "answered" | "resolved",
+      "author": "alice",
+      "pinned": false,
+      "created_at": "2026-04-30T10:00:00Z",
+      "updated_at": "2026-05-01T11:00:00Z",
+      "context": { "tab": "thresholds", "country": "Belgium" },
+      "version": { "git_sha": "abc123" },
+      "comments": [
+        { "author": "leraffl", "is_maintainer": true, "body": "fixed in #45", "created_at": "..." }
+      ]
+    }
+  ]
+}
+```
+
+### Caching
+
+- Worker side: stores the response in `caches.default` for 60 seconds keyed on `https://internal-cache/issues-v1`.
+- The `POST /issues` handler invalidates this cache after creating a new issue so the new issue shows up in the next GET.
+
+### Errors
+
+- `502` "Failed to fetch issues from GitHub" — upstream API unreachable.
+
+---
+
+## 4.2 Worker POST /issues
+
+### Purpose
+
+Validate a feedback submission and create a GitHub Issue with the right labels and metadata block.
+
+### Request
+
+```
+POST /issues
+Headers:
+  Content-Type: application/json
+  Origin: https://leraffl.github.io
+```
+
+```json
+{
+  "title": "string, ≥ 5 chars after trim",
+  "body":  "string, ≥ 10 chars after trim",
+  "category": "question" | "bug" | "idea" | "data" | "comment",
+  "author": "optional string, ≤ 60 chars (defaults to 'Anonymous')",
+  "context": { /* arbitrary JSON object — what tab the user was on, current filters */ },
+  "version": { /* arbitrary JSON object — current git_sha, build date */ },
+  "math_answer":   "string — user's answer to the captcha",
+  "math_expected": "string — the correct answer (sent by client; we re-verify)",
+  "website": "honeypot — must be empty"
+}
+```
+
+### Validation
+
+| Check | Behaviour on fail |
+|---|---|
+| `website` non-empty (honeypot) | `200 {"number":0,"ok":true}` — silent accept, no issue created. Bots think it worked, humans never trip this. |
+| Title < 5 chars | `400 "Title must be at least 5 characters."` |
+| Body < 10 chars | `400 "Description must be at least 10 characters."` |
+| Category not in allowlist | `400 "Invalid category."` |
+| Captcha missing or wrong | `400 "Incorrect answer to the captcha. Please try again."` |
+| Rate limit (`rl:<ip>` ≥ 3 in last hour) | `429 "Too many submissions. Please try again later."` |
+
+### Response 201
+
+```json
+{
+  "number": 123,
+  "title": "...",
+  "body": "...",
+  "category": "question",
+  "status": "open",
+  "author": "alice",
+  "pinned": false,
+  "created_at": "...",
+  "updated_at": "...",
+  "context": { },
+  "version": { },
+  "comments": []
+}
+```
+
+### Side effects
+
+- New Issue on `LeRaffl/LeRaffl-Gallery` with labels `feedback` + `feedback:<category>`
+- Body has appended footer `\n\n---\n*Submitted by: <author>*` plus optional `<!-- context:{...} -->` and `<!-- version:{...} -->` HTML comments for round-tripping
+- Worker cache for `GET /issues` invalidated
+
+---
+
+## 4.3 Worker POST /submissions
+
+### Purpose
+
+Accept new or corrected data rows for one country, validate, perform line-level upserts, push to a fresh branch, open a PR for maintainer review.
+
+### Request
+
+```
+POST /submissions
+Headers:
+  Content-Type: application/json
+  Origin: https://leraffl.github.io
+```
+
+```json
+{
+  "country": "Germany",
+  "variant": "Whole",
+  "source":  "KBA",
+  "author":  "optional string ≤ 60 chars",
+  "rows": [
+    {
+      "period":        "2026-04",
+      "time_interval": "monthly" | "quarterly" | "yearly",
+      "fuels": {
+        "BEV":    70663,
+        "PHEV":   29996,
+        "HEV":    87850,
+        "PETROL": 66959,
+        "DIESEL": 37664,
+        "OTHERS": 1029,
+        "TOTAL":  294161
+      },
+      "notes": "optional string ≤ 200 chars"
+    }
+  ],
+  "_hp": "honeypot — must be empty"
+}
+```
+
+### Validation
+
+| Check | Behaviour on fail |
+|---|---|
+| `_hp` non-empty | `200 {"ok":true,"pr_url":null}` — silent swallow |
+| Rate limit (`sub:<ip>` ≥ 3 in last hour) | `429 "Too many submissions. Please try again later."` |
+| `country` empty | `400 "country is required"` |
+| `variant` empty | `400 "variant is required"` |
+| `rows` empty | `400 "at least one row required"` |
+| `rows.length > 36` | `400 "too many rows in one submission"` |
+| `period` not `YYYY-MM` | `400 "invalid period \"...\""` |
+| `time_interval` not in allowlist | `400 "invalid time_interval"` |
+| Unknown fuel column | `400 "unknown fuel column \"X\""` (allowlist: BEV, PHEV, EREV, HEV, MHEV, PETROL, DIESEL, GAS, CNG, LPG, FLEXFUEL, ETHANOL, OTHERS, ICE, TOTAL) |
+| Negative or non-finite fuel value | `400 "fuel X must be a non-negative number"` |
+| `TOTAL` missing | `400 "row YYYY-MM: TOTAL is required"` |
+| `BEV` missing | `400 "row YYYY-MM: BEV is required"` |
+| `BEV + PHEV + EREV > TOTAL × 1.005` | `400 "row YYYY-MM: BEV+PHEV+EREV exceeds TOTAL"` |
+| Resulting CSV is byte-identical to current | `400 "Submission would not change the file..."` |
+
+### Side effects (on success)
+
+- Read current `data/<Country>.csv` from `master` via Contents API
+- Apply per-row upsert (key = `(period, variant)`); rows with the same key are replaced, new rows are inserted in chronological order
+- New fuel columns submitted that don't exist in the current header get appended (before `notes` if present, else end), with empty values backfilled into pre-existing rows
+- Create branch `submit/<country-slug>-<YYYYMMDDHHMMSS>` from current master HEAD
+- PUT new CSV to that branch via Contents API
+- Open PR against master with descriptive title and body listing each added/corrected row
+
+### Response 201
+
+```json
+{
+  "ok": true,
+  "pr_url": "https://github.com/LeRaffl/LeRaffl-Gallery/pull/123",
+  "pr_number": 123,
+  "branch": "submit/germany-whole-20260508120534",
+  "summary": {
+    "added": 1,
+    "replaced": 0,
+    "replacedDetails": []
+  }
+}
+```
+
+### Errors specific to GitHub propagation
+
+- `502 "Failed to read data/<Country>.csv"` — Contents GET failed
+- `502 "Failed to read master ref"` — Git Refs GET failed
+- `502 "Failed to create branch"` — Git Refs POST failed (e.g. token missing scope)
+- `502 "Failed to commit CSV"` — Contents PUT failed
+- `502 "Failed to open PR"` — Pulls POST failed
+
+Console logs from the Worker (`console.error`) record the upstream HTTP body on these failures for debugging via Cloudflare's tail viewer.
+
+### Why no Captcha here (only honeypot)?
+
+The submit form is gated by a non-trivial schema (you have to know fuel categories and provide consistent numbers). Bots historically don't bother with this kind of structured form. If spam appears, the math captcha pattern from `/issues` ports easily.
+
+---
+
+## 4.4 Worker → GitHub APIs
+
+The Worker uses these endpoints under `https://api.github.com/repos/LeRaffl/LeRaffl-Gallery`. All requests authenticate with `Authorization: Bearer <GITHUB_TOKEN>` and `X-GitHub-Api-Version: 2022-11-28`.
+
+| Worker call | GitHub endpoint | Used by |
+|---|---|---|
+| List issues with label | `GET /issues?labels=feedback&state=all&per_page=100` | `GET /issues` |
+| List issue comments | `GET /issues/<n>/comments?per_page=50` | `GET /issues` |
+| Create issue | `POST /issues` | `POST /issues` |
+| Read file content | `GET /contents/<path>?ref=master` | `POST /submissions` |
+| Read master HEAD ref | `GET /git/ref/heads/master` | `POST /submissions` |
+| Create new ref (branch) | `POST /git/refs` | `POST /submissions` |
+| Write file (with sha for update or no sha for create) | `PUT /contents/<path>` | `POST /submissions` |
+| Open pull request | `POST /pulls` | `POST /submissions` |
+
+The PAT must have these scopes (fine-grained): Issues R/W, Contents R/W, Pull requests R/W, Metadata R.
+
+---
+
+## 4.5 Page → GitHub raw.githubusercontent.com
+
+The Submit Data tab fetches `data/<Country>.csv` directly from raw GitHub on country selection, to read the header and infer which fuel-input fields to render.
+
+```
+GET https://raw.githubusercontent.com/LeRaffl/LeRaffl-Gallery/master/data/<Country>.csv
+Cache: no-store
+```
+
+If this fails (404, network), the form falls back to the canonical full set of fuel columns (`SD_FUEL_ORDER` in `index.html`). This is intentional — the form should remain submittable even if the CSV doesn't exist yet (e.g. brand-new country).
+
+---
+
+## 4.6 Static Page → GitHub Pages assets
+
+Standard relative-URL fetches for `manifest.json`, `params.csv`, `weights.csv`, `posts/<slug>.txt`, `images/<period>/<slug>_*.png`, `fleet/*.csv`, `fleet/fleet_meta.json`. All served by GitHub Pages with default 600-second cache; the page uses `cache: 'no-store'` for `manifest.json` and `posts/*` to pick up corrections fast.
+
+---
+
+## 4.7 GitHub Actions → external
+
+| Action | Reaches out to | Purpose |
+|---|---|---|
+| Render-country | Posit Public Package Manager | Pull R package binaries (`use-public-rspm: true` for fast install) |
+| Render-country, Build-manifest | The repo itself (via the workflow-scoped token) | git push images, params, weights, posts, manifest.json |
+
+Neither Action needs an outbound secret — workflow-scoped GITHUB_TOKEN is auto-injected by GitHub.
+
+## See also
+
+- [05-flows.md](05-flows.md) — sequence diagrams that show these endpoints in context
+- [07-secrets-trust.md](07-secrets-trust.md) — what the PAT can/can't do

--- a/docs/architecture/05-flows.md
+++ b/docs/architecture/05-flows.md
@@ -1,0 +1,275 @@
+# 05 · Flows
+
+End-to-end sequence diagrams for every meaningful user journey or background process. If you're adding a new flow, copy one of these as a template.
+
+## Flow inventory
+
+| # | Flow | Trigger | Outcome |
+|---|---|---|---|
+| A | [Public-submit a data point](#flow-a--public-submit) | Visitor fills Submit Data form | PR opened, awaiting maintainer review |
+| B | [Render a country](#flow-b--render-a-country) | Maintainer triggers Render Action | New PNGs + posts + params row |
+| C | [Local-render legacy](#flow-c--local-render-legacy) | Maintainer runs R in RStudio | Same outputs as Flow B, pushed directly to master |
+| D | [Submit feedback / question](#flow-d--feedback-submit) | Visitor fills feedback modal | New GitHub Issue with labels |
+| E | [Auto-rebuild manifest](#flow-e--manifest-rebuild) | Push to images/** or daily cron | Updated manifest.json |
+| F | [Visitor reads gallery](#flow-f--gallery-read) | Page load on leraffl.github.io | Manifest + images displayed |
+| G | [Copy post text](#flow-g--copy-post) | Click "📋 Copy post" or run Apple Shortcut | Text in clipboard |
+
+---
+
+## Flow A — Public-submit
+
+```mermaid
+sequenceDiagram
+    actor Visitor
+    participant Page as Static Page
+    participant Worker as Cloudflare Worker
+    participant KV as RATE_KV
+    participant GH as GitHub API
+    actor Maintainer
+
+    Visitor->>Page: Open Submit Data tab, pick Country
+    Page->>GH: GET raw/data/<Country>.csv
+    GH-->>Page: CSV content (or 404 → fallback schema)
+    Page->>Page: Render dynamic form fields per CSV header
+    Visitor->>Page: Fill rows, source, click Submit
+
+    Page->>Worker: POST /submissions {country, variant, source, rows[]}
+    Worker->>KV: GET sub:<ip>
+    KV-->>Worker: counter (or null)
+    alt Rate-limited
+        Worker-->>Page: 429
+    else OK
+        Worker->>KV: PUT sub:<ip> = counter+1, ttl=3600
+        Worker->>Worker: Validate honeypot, schema, sums
+        Worker->>GH: GET /contents/data/<Country>.csv?ref=master
+        GH-->>Worker: file content + sha
+        Worker->>Worker: Apply per-row upsert by (period, variant)
+        Worker->>GH: GET /git/ref/heads/master
+        GH-->>Worker: master sha
+        Worker->>GH: POST /git/refs (new branch from master sha)
+        Worker->>GH: PUT /contents/data/<Country>.csv (on new branch)
+        Worker->>GH: POST /pulls (open PR against master)
+        GH-->>Worker: PR url + number
+        Worker-->>Page: 201 {pr_url, summary}
+    end
+    Page->>Visitor: "Thanks! PR #N opened, X added, Y corrected"
+
+    Maintainer->>GH: Review PR diff
+    Maintainer->>GH: Merge PR
+```
+
+**After this flow:** the country's `data/<Country>.csv` on master has the new/corrected rows, but no new images yet. The maintainer triggers Flow B next to refresh PNGs and post text.
+
+**Key constraints:**
+- Worker has Contents+PRs scope but the only write the page can trigger is "open PR" — it cannot push directly to master (no permission was granted; even the API endpoints called are PR-only).
+- Branch naming `submit/<slug>-<timestamp>` makes it easy to pick out submission PRs from regular dev branches.
+
+---
+
+## Flow B — Render a country
+
+```mermaid
+sequenceDiagram
+    actor Maintainer
+    participant GHUI as GitHub Actions UI
+    participant Runner as Action Runner (Ubuntu)
+    participant Repo as GitHub Repo
+    participant Pages as GitHub Pages
+
+    Maintainer->>GHUI: Run "Render country charts" with country=Germany
+    GHUI->>Runner: dispatch
+    Runner->>Repo: actions/checkout
+    Runner->>Runner: setup-r + install ggplot2/scales/grid/png/ggtext/viridis/showtext/sysfonts/glue
+    Runner->>Runner: Rscript R/render_country.R Germany Whole
+
+    Note over Runner: Inside the R script:<br/>1. load_country_csv(data/Germany.csv)<br/>2. fit_history(df) → params, history-loop<br/>3. build_post_text(df, "Germany")<br/>4. plot_bev_trajectory / plot_ice_bev_phev / plot_timer / plot_ttm_shares<br/>5. ggsave 4 PNGs to images/<period>/<br/>6. upsert_params, upsert_weights<br/>7. writeLines posts/<slug>.txt, posts/<slug>_<period>.txt
+
+    Runner->>Repo: git add images/ params.csv weights.csv posts/
+    Runner->>Repo: git commit -m "chore: render Germany (Whole)"
+    Runner->>Repo: git push origin master
+
+    Repo->>Pages: deploy hook
+    Pages->>Pages: serve updated assets
+```
+
+After this, Flow E (manifest rebuild) is auto-triggered by the push to `images/**`.
+
+**Performance notes:**
+- Cold runner: ~2 min including R-package install
+- Warm runner (cached binaries): ~30 s
+- The R history-loop iterates `optim` once per data row × 2 (BEV + ICE). For Germany (~135 rows): ~3 s. For Norway (~250 rows): ~6 s.
+
+---
+
+## Flow C — Local-render legacy
+
+```mermaid
+sequenceDiagram
+    actor Maintainer
+    participant RStudio
+    participant GS as Google Sheets
+    participant LocalRepo as Local clone
+    participant Repo as GitHub Repo
+
+    Maintainer->>RStudio: source(bev_share_<Country>.R)
+    RStudio->>GS: read_sheet(<sheet_url>)
+    GS-->>RStudio: data frame
+    RStudio->>RStudio: fit + plot + post-text (same logic, copied to per-country script)
+    RStudio->>LocalRepo: writeLines images/<period>/<slug>_*.png
+    RStudio->>LocalRepo: upsert params.csv, weights.csv
+    RStudio->>LocalRepo: writeLines posts/<slug>.txt, posts/<slug>_<period>.txt
+    RStudio->>Repo: git add + commit + push (via gert)
+    Repo->>Repo: build-manifest workflow triggers on images/** push
+```
+
+**Why this still exists alongside Flow B:**
+- Faster iteration (no CI cold-start, can use RStudio breakpoints)
+- Still the maintainer's preferred path during data-collection phase
+- Outputs are byte-compatible with Flow B (same filenames, same params row format)
+
+**Risk and mitigation:**
+- Risk: local R drift from the new pipeline (different package versions, different plotting code)
+- Mitigation: any time the new pipeline changes its plotting or fitting code, the maintainer should pull those changes back into the local scripts — or eventually retire the local scripts entirely
+
+---
+
+## Flow D — Feedback submit
+
+```mermaid
+sequenceDiagram
+    actor Visitor
+    participant Page as Static Page
+    participant Worker as Cloudflare Worker
+    participant KV as RATE_KV
+    participant GH as GitHub Issues
+    actor Maintainer
+
+    Visitor->>Page: Click FAB or "New topic"
+    Page->>Visitor: Open feedback modal, generate captcha question
+    Visitor->>Page: Fill title/body/category/captcha, submit
+
+    Page->>Worker: POST /issues {title, body, category, captcha, context, version}
+    Worker->>KV: GET rl:<ip>
+    KV-->>Worker: counter
+    alt Rate-limited
+        Worker-->>Page: 429
+    else
+        Worker->>Worker: Validate honeypot, lengths, captcha
+        Worker->>GH: POST /issues with labels feedback + feedback:<category>
+        GH-->>Worker: issue object
+        Worker->>Worker: Invalidate /issues cache
+        Worker-->>Page: 201 mappedIssue
+    end
+    Page->>Visitor: Show new issue inline in Feedback tab
+
+    Maintainer->>GH: (later) Comment / close
+    Note over GH: Page's GET /issues picks up<br/>the comment + status change<br/>on next refresh (60 s cache)
+```
+
+---
+
+## Flow E — Manifest rebuild
+
+```mermaid
+sequenceDiagram
+    participant Repo as GitHub Repo
+    participant Action as build-manifest Action
+    participant Runner as Action Runner
+
+    alt Push to images/**
+        Repo-->>Action: trigger
+    else Push to build_manifest.R
+        Repo-->>Action: trigger
+    else Daily cron 03:17 UTC
+        Action-->>Action: schedule fires
+    else Manual dispatch
+        Action-->>Action: workflow_dispatch
+    end
+
+    Action->>Runner: dispatch
+    Runner->>Repo: checkout
+    Runner->>Runner: setup-r + install jsonlite, stringr, dplyr, lubridate, purrr, fs, tibble
+    Runner->>Runner: Rscript -e source('build_manifest.R'); build_manifest(...)
+    Runner->>Runner: scan images/, derive country/variant/period/type per filename
+    Runner->>Runner: write manifest.json
+    Runner->>Repo: git add manifest.json
+    Runner->>Repo: git commit (only if changed)
+    Runner->>Repo: git push
+```
+
+---
+
+## Flow F — Gallery read
+
+```mermaid
+sequenceDiagram
+    actor Visitor
+    participant Browser
+    participant Pages as GitHub Pages
+    participant Repo as GitHub Repo
+
+    Visitor->>Browser: navigate to leraffl.github.io/LeRaffl-Gallery
+    Browser->>Pages: GET /
+    Pages-->>Browser: index.html
+    Browser->>Pages: GET manifest.json (no-store)
+    Pages-->>Browser: JSON
+    Browser->>Browser: build Gallery cards from manifest.images
+    par (in parallel for each visible card)
+        Browser->>Pages: GET images/<period>/<slug>_*.png
+        Pages-->>Browser: PNG
+    end
+    par (on tab switch)
+        Browser->>Pages: GET params.csv (Builder/Thresholds/Durations/Map)
+        Pages-->>Browser: CSV
+    end
+```
+
+This flow is intentionally trivial. **Any change that adds a backend dependency to the read path is a regression.** The page is read-side static; only the write side (Submit, Feedback) goes through the Worker.
+
+---
+
+## Flow G — Copy post
+
+Two variants: in-page button, and Apple Shortcut. Both fetch the same URL.
+
+### G.1 In-page
+
+```mermaid
+sequenceDiagram
+    actor Visitor
+    participant Page as Static Page
+    participant Pages as GitHub Pages
+    participant Clipboard
+
+    Visitor->>Page: Click "📋 Copy post" on a Germany card
+    Page->>Pages: GET posts/germany.txt (no-store)
+    Pages-->>Page: text/plain
+    Page->>Clipboard: navigator.clipboard.writeText(text)
+    Page->>Visitor: Button briefly shows "✓ Copied"
+```
+
+### G.2 Apple Shortcut
+
+```mermaid
+sequenceDiagram
+    actor Maintainer
+    participant Shortcuts as Apple Shortcuts
+    participant Raw as raw.githubusercontent.com
+    participant Clipboard
+
+    Maintainer->>Shortcuts: Tap "BEV Post Picker"
+    Shortcuts->>Maintainer: Choose from Menu (country list)
+    Maintainer->>Shortcuts: Pick "Germany"
+    Shortcuts->>Raw: GET /LeRaffl/LeRaffl-Gallery/master/posts/germany.txt
+    Raw-->>Shortcuts: text/plain
+    Shortcuts->>Clipboard: Copy
+    Shortcuts->>Maintainer: Notification "Germany post copied"
+```
+
+**Why two paths to the same artefact:** the in-page button is for visitors and casual mobile/desktop use; the Shortcut is for the maintainer's posting workflow on iOS where launching Safari is more friction than tapping a Shortcut on the home screen.
+
+## See also
+
+- [04-interfaces.md](04-interfaces.md) — request/response shapes for each Worker call shown above
+- [02-components.md](02-components.md) — the boxes in the diagrams
+- [08-deploy-ops.md](08-deploy-ops.md) — how to invoke Flow B, how to debug Flow A failures

--- a/docs/architecture/05-flows.md
+++ b/docs/architecture/05-flows.md
@@ -122,14 +122,9 @@ sequenceDiagram
     Repo->>Repo: build-manifest workflow triggers on images/** push
 ```
 
-**Why this still exists alongside Flow B:**
-- Faster iteration (no CI cold-start, can use RStudio breakpoints)
-- Still the maintainer's preferred path during data-collection phase
-- Outputs are byte-compatible with Flow B (same filenames, same params row format)
-
-**Risk and mitigation:**
-- Risk: local R drift from the new pipeline (different package versions, different plotting code)
-- Mitigation: any time the new pipeline changes its plotting or fitting code, the maintainer should pull those changes back into the local scripts — or eventually retire the local scripts entirely
+**Why this exists at all (context for engineers):**
+- Outputs are byte-compatible with Flow B — same filenames, same params row format, same posts format. So commits to master can come from either path without confusing downstream consumers.
+- This path is being phased out as more data flows directly through Submit → PR → Render Action. Eventually Flow B becomes the only render path. Any new feature in `R/*.R` should be designed assuming Flow B is the canonical path.
 
 ---
 
@@ -173,23 +168,15 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant Repo as GitHub Repo
-    participant Action as build-manifest Action
+    participant Action as Build-manifest Action
     participant Runner as Action Runner
 
-    alt Push to images/**
-        Repo-->>Action: trigger
-    else Push to build_manifest.R
-        Repo-->>Action: trigger
-    else Daily cron 03:17 UTC
-        Action-->>Action: schedule fires
-    else Manual dispatch
-        Action-->>Action: workflow_dispatch
-    end
-
+    Note over Repo,Action: Trigger sources (any one of):<br/>• push to images/**<br/>• push to build_manifest.R<br/>• daily cron 03:17 UTC<br/>• manual workflow_dispatch
+    Repo->>Action: workflow trigger
     Action->>Runner: dispatch
     Runner->>Repo: checkout
-    Runner->>Runner: setup-r + install jsonlite, stringr, dplyr, lubridate, purrr, fs, tibble
-    Runner->>Runner: Rscript -e source('build_manifest.R'); build_manifest(...)
+    Runner->>Runner: setup-r + install jsonlite/stringr/dplyr/lubridate/purrr/fs/tibble
+    Runner->>Runner: Rscript build_manifest.R
     Runner->>Runner: scan images/, derive country/variant/period/type per filename
     Runner->>Runner: write manifest.json
     Runner->>Repo: git add manifest.json

--- a/docs/architecture/06-tech-stack.md
+++ b/docs/architecture/06-tech-stack.md
@@ -1,0 +1,110 @@
+# 06 · Tech Stack
+
+What runs where, what version, what package.
+
+## Language and runtime matrix
+
+| Layer | Tech | Where | Version constraint |
+|---|---|---|---|
+| Frontend rendering | HTML5 + CSS3 + ES2020 JavaScript | `index.html` | Whatever evergreen browsers support today; no transpiler |
+| Edge compute | JavaScript (V8 isolate, Workers runtime) | `worker/index.js` | `compatibility_date = 2026-04-25` in `wrangler.toml` |
+| Data pipeline | R | `R/*.R`, `build_manifest.R` | R 4.5+ (CI uses `r-lib/actions/setup-r@v2` default) |
+| CI orchestration | YAML for GitHub Actions | `.github/workflows/*.yml` | GitHub Actions current |
+| Build / packaging | None | — | Static site, no bundler |
+
+## R package dependencies
+
+### Render-country pipeline (`R/*.R`, used by `render-country.yml`)
+
+| Package | Used in | Why |
+|---|---|---|
+| `ggplot2` | plots.R | All plotting |
+| `scales` | plots.R | `unit_format`, `percent_format` axis labels |
+| `grid` | plots.R | `rasterGrob` for flag overlays |
+| `png` | render_country.R | Read flag PNG into a raster |
+| `ggtext` | plots.R | `element_markdown` for rich-text caption |
+| `viridis` | plots.R | TTM stack colour palette |
+| `showtext` | render_country.R | Render FontAwesome glyphs in captions |
+| `sysfonts` | render_country.R | `font_add` for FA OTF files |
+| `glue` | render_country.R | String interpolation for the social caption |
+
+`R/fit.R` and `R/upsert.R` are pure base R — no extra packages.
+
+### Manifest builder (`build_manifest.R`, used by `build-manifest.yml`)
+
+| Package | Why |
+|---|---|
+| `jsonlite` | Write JSON |
+| `stringr` | Filename parsing |
+| `dplyr` | Frame manipulation |
+| `lubridate` | Date parsing from filename suffix |
+| `purrr` | Map over images/ tree |
+| `fs` | Filesystem traversal |
+| `tibble` | Lightweight frame |
+
+### Legacy local R (off-repo)
+
+The maintainer's per-country scripts pull `gert` (Git ops), `googlesheets4` (Google Sheets read), `readxl`, `tidyr`, `reshape2`, `xts`, `tidyquant`, `patchwork`, `lubridate`, `ggcorrplot`, `gridExtra`, `htmltools`, `fontawesome`, `emojifont`, on top of the render-pipeline set. None of those are needed in CI.
+
+## Frontend dependencies
+
+The page intentionally has **zero JS dependencies**. No React, Vue, jQuery, lodash, d3. Implementation:
+- Plotly is loaded **on demand** for the Builder/Fleet tabs only, from a CDN, with `loading="lazy"`-style late inclusion.
+- All other interactivity is hand-rolled vanilla DOM manipulation.
+
+CDN inclusions (current):
+- Plotly via CDN script tag (used in Builder, Fleet)
+- That's it
+
+## Worker dependencies
+
+Pure ES module. No npm dependencies, no build step. The Workers runtime supplies `fetch`, `Request`, `Response`, `URL`, `caches`, KV bindings, `btoa`/`atob`. All HTTP work is direct `fetch`.
+
+`wrangler.toml` declares:
+```toml
+name               = "leraffl-gallery-feedback"
+main               = "index.js"
+compatibility_date = "2026-04-25"
+account_id         = "<redacted>"
+preview_urls       = false
+
+[observability]
+enabled = true
+[observability.logs]
+enabled = true
+
+[vars]
+GITHUB_OWNER = "leraffl"
+GITHUB_REPO  = "leraffl-gallery"
+
+[[kv_namespaces]]
+binding = "RATE_KV"
+id      = "<redacted>"
+```
+
+## CI runner stack
+
+- `actions/checkout@v4` — pull source
+- `r-lib/actions/setup-r@v2` (with `use-public-rspm: true` for fast package binaries on Ubuntu)
+- `r-lib/actions/setup-r-dependencies@v2` — install the package list with apt prebuilds
+- `EndBug/add-and-commit@v9` — commit and push outputs back
+
+## Hosting / SaaS
+
+| Service | Tier | What it runs |
+|---|---|---|
+| GitHub | Free public repo | Source, Issues, PRs, Actions, Pages |
+| Cloudflare Workers | Free | The edge worker |
+| Cloudflare KV | Free (under 1k writes/day, 100k reads/day) | Rate-limit counters |
+| Posit Public Package Manager | Free | R package binaries for CI |
+
+No paid services in the critical path. The Cloudflare account does not have a billing card attached for this project.
+
+## Why "no build step" everywhere
+
+For a one-maintainer project documenting public data, every minute spent fixing a Webpack config or Babel preset is a minute not spent on data quality. The codebase is small enough that vanilla JS + plain R + plain CSS is faster to evolve than any framework. If this project ever grows past one maintainer, this is a decision to revisit.
+
+## See also
+
+- [02-components.md](02-components.md) — what each runtime is hosting
+- [08-deploy-ops.md](08-deploy-ops.md) — install/deploy commands per layer

--- a/docs/architecture/07-secrets-trust.md
+++ b/docs/architecture/07-secrets-trust.md
@@ -1,0 +1,124 @@
+# 07 · Secrets and Trust
+
+What can be done by whom. What an attacker can and cannot accomplish. Where credentials live. No tokens or IDs are reproduced in this file.
+
+## Trust-boundary diagram
+
+```mermaid
+flowchart LR
+    subgraph Public["Public — anyone on the internet"]
+        Visitor[Visitor / Attacker]
+    end
+    subgraph Edge["Cloudflare Edge"]
+        Worker[Worker]
+        KV[(KV)]
+    end
+    subgraph GH["GitHub"]
+        Repo[(Repo)]
+        Issues[(Issues)]
+        PRs[(PRs)]
+    end
+    subgraph LM["Maintainer's machine"]
+        Mac[macOS Keychain]
+    end
+
+    Visitor -- HTTPS, CORS, captcha, honeypot, rate-limit --> Worker
+    Worker -- Bearer PAT (scoped) --> Issues
+    Worker -- Bearer PAT (scoped) --> PRs
+    Worker -- Bearer PAT (scoped) --> Repo
+    Worker -- read/write counters --> KV
+    Mac -- direct git push (OAuth keychain) --> Repo
+    Mac -- direct write (OAuth) --> KV
+```
+
+The five trust boundaries to reason about:
+
+1. **Public ↔ Worker** — adversarial. Defended by CORS, captcha, honeypot, rate-limit, schema validation.
+2. **Worker ↔ GitHub** — Worker holds a fine-grained PAT; constrained to PR-only writes for data, full R/W on issues.
+3. **GitHub Actions ↔ Repo** — Actions hold the workflow-scoped GITHUB_TOKEN, can push to master.
+4. **Maintainer ↔ Repo** — full write access via personal OAuth.
+5. **Maintainer ↔ Cloudflare** — full account access via wrangler OAuth in macOS Keychain.
+
+## Secret inventory
+
+| Secret | Type | Where it lives | Scope / capability | Rotation |
+|---|---|---|---|---|
+| `GITHUB_TOKEN` (Worker) | Fine-grained PAT | Cloudflare Worker secret (set via `npx wrangler secret put GITHUB_TOKEN`) | Repo: `LeRaffl/LeRaffl-Gallery` only. Permissions: Issues R/W, Contents R/W, Pull requests R/W, Metadata R | Manual; no expiry currently set. Rotate by editing the PAT in GitHub settings; token value stays; if regenerated, re-`wrangler secret put`. |
+| `GITHUB_TOKEN` (workflow) | GitHub-managed | Auto-injected by Actions per run | Repo-write within the workflow's run; ephemeral | Auto |
+| Cloudflare API token | OAuth | macOS Keychain (via `npx wrangler login`) | Full account; covers Workers, KV, Pages | When `wrangler login` is re-run |
+| Git push credentials | OAuth | macOS Keychain | The maintainer's GitHub identity (personal write) | When user revokes from GitHub Settings → Applications |
+| Google Sheets OAuth | OAuth | Local R session, stored in `~/.cache/gargle` | Read-only access to specific sheets | Auto-refreshes; revoke from Google Account |
+
+**Tokens and IDs are never committed to the repo.** The `GITHUB_TOKEN` value lives only in Cloudflare's secret store; even the maintainer's local machine doesn't keep a long-lived copy after `wrangler secret put`. The Cloudflare account ID and KV namespace ID are in `wrangler.toml` but those are not secrets — they're public-bound identifiers, useless without the API token.
+
+## What the Worker's PAT can and cannot do
+
+**Can:**
+- Read any file in the repo (Contents R)
+- Create branches and commit changes to them (Contents W + Git Refs API)
+- Open pull requests against master (Pulls W)
+- Read issues, create issues, comment on issues (Issues R/W)
+
+**Cannot:**
+- Push directly to master (would require admin override; not granted)
+- Force-push to any branch (no Force-push permission)
+- Modify repo settings, secrets, or webhooks
+- Read or modify other repos in the organisation
+- Read repo secrets (no Secrets permission)
+
+This is the architectural firewall: even if the Worker were fully compromised, the worst an attacker could do is open spam PRs (which the maintainer can close) or post spam issues (which can be auto-hidden by adding the `hidden` label). They cannot land code or data without human review.
+
+## Threat model — Public Submit endpoint
+
+| Threat | Mitigation |
+|---|---|
+| Spam submissions to drown the maintainer in PRs | KV rate-limit `sub:<ip>` ≥ 3 in 60 min returns 429. Honeypot field silently swallows bots that auto-fill all inputs. Schema validation rejects malformed rows immediately. |
+| Submitting fake numbers to corrupt data | All submissions are PR-based; maintainer reviews before merge. PR diff shows exactly what changed, so subtle tampering is visible. |
+| Submitting valid-looking but historically wrong data | Same — review gate. The maintainer cross-checks the submitted source URL with the cited number. |
+| DoS via large payloads | `rows.length > 36` rejected. Each row's payload is bounded (`notes` ≤ 200 chars, `country/variant` ≤ 60/30 chars). |
+| Submitting unsupported fuel column to crash the renderer | `ALLOWED_FUEL_COLS` allowlist rejects anything not on the canonical list. |
+| Crafting `country` with `../` to write outside `data/` | The Worker URL-encodes `country` for the GitHub API path, so `../` becomes `..%2F`. Even if the encoding failed, the GitHub API itself doesn't expose paths outside the repo. |
+| Race conditions between two simultaneous submissions for the same country | Each submission opens a new branch off whatever master is at the time. If a second submission lands while a first PR is open, the second PR's branch will diverge from the first; merging both produces a normal git merge resolution. The maintainer reviews each independently. |
+
+## Threat model — Public Feedback endpoint
+
+| Threat | Mitigation |
+|---|---|
+| Spam issue creation | Math captcha (3+4=?), honeypot, KV rate-limit `rl:<ip>` |
+| Posting personally-identifying info publicly | Privacy notice in the modal warns the user; submission is irreversible from their side — they need to ask the maintainer to redact via a regular issue close+hide. |
+| Phishing links in issue body | GitHub auto-renders URLs but not as clickable rich-text in many surfaces; users see raw URLs. The maintainer can `hidden`-label any issue in seconds. |
+
+## Why the Worker is on the critical write path even though static-pages-direct would be simpler
+
+A pure static-page can't talk to the GitHub API in a way that's safe — the PAT would be exposed in client JS. The Worker:
+- Holds the PAT server-side
+- Adds a CORS check (`Origin` must match `https://leraffl.github.io`) so other origins can't even reach the endpoint from a browser
+- Adds rate-limiting that wouldn't be feasible client-side
+- Adds schema validation that runs in a trusted context
+
+Removing the Worker means either embedding a token in the page (no), implementing a different write strategy (e.g. GitHub Issue Forms, which has worse UX), or running a small backend somewhere else (same complexity).
+
+## Cloudflare-side hardening
+
+- `compatibility_date` pinned in `wrangler.toml` → runtime behaviour is reproducible
+- `observability.enabled = true` and `logs.enabled = true` → tail logs visible in dashboard for debugging
+- `preview_urls = false` → no public preview URL is exposed alongside production deployments
+- KV namespace IDs are not secrets but are scoped to this Worker's namespace by binding name
+
+## Rotation playbook
+
+If the Worker's PAT leaks (Cloudflare logs exposed, secret accidentally printed):
+1. Go to GitHub Settings → Personal access tokens → fine-grained → revoke `leraffl-gallery-feedback-worker`
+2. Create a new fine-grained PAT with the same four scopes scoped to the repo
+3. `cd worker && npx wrangler@latest secret put GITHUB_TOKEN` and paste the new value
+4. Verify via `Test feedback submission` and `Test data submission` end-to-end
+5. No code changes required
+
+If the Cloudflare API token is suspected compromised:
+1. Cloudflare dashboard → My Profile → API Tokens → revoke the OAuth session
+2. `npx wrangler@latest login` again on the maintainer's Mac
+
+## See also
+
+- [04-interfaces.md § validation tables](04-interfaces.md) — exact validation rules
+- [08-deploy-ops.md](08-deploy-ops.md) — operational steps to deploy/rotate

--- a/docs/architecture/08-deploy-ops.md
+++ b/docs/architecture/08-deploy-ops.md
@@ -1,0 +1,205 @@
+# 08 · Deploy and Ops
+
+Operational runbook. How to deploy, how to trigger, how to debug. Commands you can copy.
+
+## Quick reference
+
+| Task | Command | Section |
+|---|---|---|
+| Deploy worker code change | `cd worker && npx wrangler@latest deploy` | [§ 8.1](#81-deploy-the-worker) |
+| Re-render one country | Actions tab → "Render country charts" → Run workflow | [§ 8.2](#82-trigger-a-country-render) |
+| Add a new country | Extract CSV, push, run render | [§ 8.3](#83-add-a-new-country) |
+| Rotate the Worker's PAT | Edit PAT in GitHub, re-`wrangler secret put` | [§ 8.4](#84-rotate-secrets) |
+| Merge a public submission | Review PR diff, click Merge, then [§ 8.2](#82-trigger-a-country-render) | [§ 8.5](#85-process-a-submission-pr) |
+| Hide spam feedback | Add `hidden` label to the issue | [§ 8.6](#86-moderate-feedback) |
+| Bulk-render all countries | Loop through countries calling [§ 8.2](#82-trigger-a-country-render) one at a time | [§ 8.7](#87-bulk-rerender) |
+| Debug Worker errors | Cloudflare dashboard → Workers → Tail logs | [§ 8.8](#88-debugging) |
+
+## 8.1 Deploy the Worker
+
+Required when **any** of these change:
+- `worker/index.js`
+- `worker/wrangler.toml` (compat date, KV bindings, account_id, vars)
+- The Worker's `GITHUB_TOKEN` secret (set separately, see § 8.4)
+
+```bash
+cd /Users/leraffl/Projects/GitHub/LeRaffl-Gallery/worker
+npx wrangler@latest deploy
+```
+
+**What you should see:**
+```
+Total Upload: ~20 KiB / gzip: ~6 KiB
+Your Worker has access to the following bindings:
+  env.RATE_KV       (...)        KV Namespace
+  env.GITHUB_OWNER  ("leraffl")  Environment Variable
+  env.GITHUB_REPO   ("leraffl-gallery")  Environment Variable
+Uploaded leraffl-gallery-feedback (~10 sec)
+Deployed leraffl-gallery-feedback triggers (~5 sec)
+  https://leraffl-gallery-feedback.xgwvfz7nrb.workers.dev
+```
+
+If wrangler prompts about a config diff between local and remote, **say no** and reconcile the diff first (usually means someone tweaked the worker via the Cloudflare dashboard; pull those settings into `wrangler.toml`).
+
+## 8.2 Trigger a country render
+
+Required after:
+- Merging a public submission PR
+- Pushing new data via local R / direct CSV edit
+- Any change to `R/*.R` that affects rendered output
+
+Steps:
+1. Open <https://github.com/LeRaffl/LeRaffl-Gallery/actions/workflows/render-country.yml>
+2. Click "Run workflow" (top-right)
+3. Pick branch `master`
+4. Fill `country` (e.g. `Germany`) and `variant` (default `Whole`)
+5. Click "Run workflow"
+
+The action takes 30–120 s and commits four PNGs + params/weights row update + posts files. The Build-manifest action triggers automatically on the resulting `images/**` push.
+
+**You can also trigger via gh CLI:**
+```bash
+gh workflow run render-country.yml -f country=Germany -f variant=Whole
+gh run watch  # follow the latest run
+```
+
+## 8.3 Add a new country
+
+End-to-end, the cheapest path:
+
+1. **Extract CSV from the source sheet.** The python extractor in past PRs is a good template — copy the loop, adjust `RENAME` if the country has unusual column names, write to `data/<Country>.csv`.
+2. **Add to `SD_COUNTRIES`** in `index.html` (alphabetical):
+   ```js
+   { country: 'NewLand', variants: ['Whole'] },
+   ```
+3. **Add a flag asset** at `assets/flags/<slug>.png` (lowercase, non-alphanumerics → `_`). Copy from the existing flag store or download from a flag asset library; keep at ~64×40 px or similar.
+4. **Update `R/post_text.R::.pt_flag`** to map the country name to its emoji flag (regional indicator pair).
+5. **Commit**, push, open PR.
+6. After merge, run § 8.2 to render.
+
+## 8.4 Rotate secrets
+
+### Worker GITHUB_TOKEN
+
+If the value didn't leak, just edit the existing fine-grained PAT to extend permissions; the token value stays the same. No `wrangler secret put` needed.
+
+If the value did leak or you want to rotate proactively:
+1. <https://github.com/settings/personal-access-tokens> → find `leraffl-gallery-feedback-worker` → "Regenerate token" (or revoke + create new)
+2. Copy the new token
+3. ```bash
+   cd worker
+   npx wrangler@latest secret put GITHUB_TOKEN
+   # paste the new value when prompted
+   ```
+4. Verify by submitting a test feedback issue and a test data row, both should succeed.
+
+Required scopes (fine-grained PAT on `LeRaffl/LeRaffl-Gallery`):
+- Issues: Read and write
+- Contents: Read and write
+- Pull requests: Read and write
+- Metadata: Read
+
+### Cloudflare wrangler session
+
+```bash
+npx wrangler@latest login
+```
+Browser opens, OAuth flow, session is stored in macOS Keychain. Old session in Keychain is overwritten.
+
+## 8.5 Process a submission PR
+
+When a `submit/<country>-<variant>-<ts>` PR appears:
+
+1. Open the PR. Title is `data: <Country> (<Variant>) — <N> added, <M> corrected`.
+2. **Body lists each row** with before/after for corrections and added rows verbatim. Quick-check that the numbers look plausible against the cited source.
+3. **Look at the file diff** (Files changed tab). Should be exactly one file: `data/<Country>.csv`. If it touches anything else, that's a bug — close without merging and ping the developer.
+4. If the data looks right, click "Merge pull request" → squash recommended.
+5. Run § 8.2 with the country to refresh PNGs, params, weights, and posts.
+6. After the render commits land, the page auto-refreshes within ~1 minute.
+
+If the data looks wrong:
+- Comment on the PR explaining what's off.
+- Either close without merging, or push a correction commit to the same branch and merge that.
+
+## 8.6 Moderate feedback
+
+| Action | How |
+|---|---|
+| Hide a spam/abusive issue from the page | Add label `hidden` on the GitHub issue. The Worker filters it out of `GET /issues`. |
+| Pin an important issue | Add label `pinned`. The page sorts pinned issues to the top. |
+| Mark resolved | Close the issue. Page status flips to `resolved`. |
+| Mark answered | Comment on the issue as `LeRaffl`. Page derives `answered` status automatically. |
+| Wipe the cache so a change shows up faster | Trigger any new POST `/issues` or wait 60 s for the worker cache to expire. |
+
+## 8.7 Bulk re-render
+
+After a refactor that affects rendering for all countries (e.g. plot style change), you need to re-render every country. Two approaches:
+
+### Locally (fastest)
+```bash
+for c in data/*.csv; do
+  name=$(basename "$c" .csv)
+  Rscript R/render_country.R "$name"
+done
+git add images/ params.csv weights.csv posts/
+git commit -m "chore: bulk re-render after <reason>"
+git push
+```
+
+### Via CI (if you want CI to be the source of truth)
+```bash
+for c in Germany Austria France ...; do
+  gh workflow run render-country.yml -f country="$c" -f variant=Whole
+  sleep 60   # let each run finish to avoid concurrency throttling
+done
+```
+
+CI is slower (~30–120 s × 43 countries) but produces deterministic byte-output regardless of which Mac the maintainer happens to be on.
+
+## 8.8 Debugging
+
+### Worker isn't responding
+
+1. Cloudflare dashboard → Workers → `leraffl-gallery-feedback` → Logs (tail)
+2. Reproduce the failing request from the page
+3. Look for `console.error` lines — typical issues:
+   - `Branch create failed: 403 ...` → PAT missing Contents/Pulls scope. Re-extend (§ 8.4).
+   - `Failed to read data/<Country>.csv` → file doesn't exist on master yet. Either add the CSV first or wait for the submitter to be more patient.
+   - `Too many submissions` → working as intended, KV rate-limit fired.
+
+### Render Action failing
+
+1. Open the failed run in the Actions tab.
+2. Common failures:
+   - **`missing data file: data/<Country>.csv`** → the country isn't in the repo. Add it via § 8.3.
+   - **`no rows for variant 'X' in data/<Country>.csv`** → variant not present in the CSV. Either submit data for it or change the variant input.
+   - **`Failed to install package 'showtext'` or similar** → CI cache miss + apt prebuild missing. Re-run; usually transient.
+   - **`Error in optim(...)`** → degenerate input (all-zero column, single data point). Check the CSV for the period range.
+
+### Site shows stale data after a render
+
+1. Was the Render Action's commit pushed? `gh run view <id>` should show `chore: render <Country> ...` as the last commit.
+2. Did the Build-manifest action run after? Check Actions tab.
+3. Did Pages deploy? Settings → Pages → Recent deployments.
+4. Hard-refresh the page (`Cmd+Shift+R`) to bypass browser cache.
+
+### Submit form is showing all 14 fuel categories instead of the country's actual subset
+
+The page's CSV-fetch fallback kicked in. Either:
+- The branch with the country's CSV isn't merged yet (check master)
+- raw.githubusercontent.com had a transient 5xx (rare)
+
+## 8.9 Restoring from disaster
+
+| Disaster | Recovery |
+|---|---|
+| Repo deleted / corrupted | Restore from any clone — every artefact is in Git |
+| Cloudflare account lost | Re-create Worker via wrangler, re-set secret, re-bind KV. The KV's rate-limit data is lost but uncritical. |
+| Maintainer's Mac lost | Clone the repo on a new machine, `wrangler login`, `gitcreds_set` for git OAuth, done. The local R scripts (`bev_share_*.R`) are off-repo and need to be restored from iCloud or a backup; if not, the in-repo `R/` pipeline alone is sufficient. |
+| GitHub down | Read-side serves from GitHub Pages CDN, may stay up briefly. Submit/feedback writes fail — Worker returns 502; page shows error. Wait for GitHub. |
+
+## See also
+
+- [02-components.md](02-components.md) — what each component does
+- [04-interfaces.md](04-interfaces.md) — request/response shapes for the Worker
+- [07-secrets-trust.md](07-secrets-trust.md) — what each token can do

--- a/docs/architecture/09-glossary.md
+++ b/docs/architecture/09-glossary.md
@@ -1,0 +1,92 @@
+# 09 · Glossary
+
+Domain jargon used across the codebase, the data, and the chats. Look here when an LLM session or a new contributor asks "what does X mean".
+
+## Vehicle / fuel categories
+
+| Term | Meaning | Notes |
+|---|---|---|
+| **BEV** | Battery Electric Vehicle | Pure-electric, no combustion engine. The headline metric. |
+| **PHEV** | Plug-in Hybrid Electric Vehicle | Has both a battery (chargeable from outside) and a combustion engine. |
+| **EREV** | Extended-Range Electric Vehicle | A specific PHEV variant where the engine only acts as a generator for the battery. Some sources (notably China's CPCA from 2025-01-01 onwards) report this separately from PHEV. In our 3-curve plot, EREV is folded into PHEV. In the TTM stack, EREV is its own layer. |
+| **HEV** | (Full) Hybrid Electric Vehicle | Battery is regen-charged only, can't be plugged in. Counts as ICE in our 3-curve rollup; renders as a parenthetical "of which Xp were HEV" in the post text. |
+| **MHEV** | Mild Hybrid | Small battery assist; effectively ICE. Reserved column, not yet used. |
+| **PETROL / DIESEL / FLEXFUEL / ETHANOL** | Conventional ICE subcategories | Where reported. |
+| **GAS / CNG / LPG** | Gas-powered ICE variants | Reserved columns; only Georgia currently uses GAS (via a re-mapped PETROL-GAS column). |
+| **OTHERS** | Catch-all | Any fuel not fitting the named categories. |
+| **ICE** | Internal Combustion Engine, single bucket | Used by countries (China, USA, South Korea, Thailand, Chile) that don't break ICE down further. In the 3-curve rollup ICE is *derived* (TOTAL − BEV − PHEV − EREV); when reported as an explicit column it's used directly in the TTM stack. |
+| **TOTAL** | All registrations in the period | Required field. The denominator for every share computation. |
+| **Hybrid (capital, no qualifier)** | A country's single combined hybrid bucket | Some sources (Türkiye `HYBRIDS`, Georgia `Hybrid`) don't split PHEV vs HEV. In our schema this maps to the `HEV` column and the post text labels it as "Hybrid" without parentheses. |
+
+## Time / period
+
+| Term | Meaning |
+|---|---|
+| **period** | A YYYY-MM string identifying the data point. Quarterly entries use the middle month (Q1→Feb, Q2→May, Q3→Aug, Q4→Nov). Yearly entries use July (`YYYY-07`). |
+| **time_interval** | One of `monthly`, `quarterly`, `yearly`. Drives how the row is plotted and aggregated. |
+| **TTM** | Trailing Twelve Months. Rolling sum of the last 12 monthly rows; shown as the `_ttm_shares` chart and as the second block in the post text. |
+| **data_per** | The `period` of the most recent data row this fit was based on. Lives in `params.csv` and `weights.csv`. |
+| **model_date** | The day the fit was last run, in `YYYY-MM-DD`. Mostly informational. |
+| **baseline_date** | Reserved field in `params.csv`; always blank currently. |
+
+## Identifiers and naming
+
+| Term | Meaning | Example |
+|---|---|---|
+| **slug** | Lowercase form of country (and optionally variant) with non-alphanumerics replaced by `_`. Used in image filenames and post filenames. | `germany`, `new_zealand`, `denmark_hdv` |
+| **country** | The display name of the country | `Germany`, `Türkiye`, `New Zealand` |
+| **variant** | A within-country slice | `Whole` (default — labelled "New Cars" in the UI), `Custom`, `HDV`, `Vans`, `Private`, `Industry`, `2-Wheelers`, `3-Wheelers`, `4-Wheelers`, `Used`, `Used Imports`, `Fleet` |
+| **type** (in chart filenames) | One of the four canonical chart types | empty (BEV trajectory), `ICE_BEV`, `time`, `ttm_shares` |
+
+## Model parameters
+
+| Term | Meaning |
+|---|---|
+| **v1, v2, t0** | The three parameters of the BEV-curve fit. The curve is `share(t) = 1 − exp(v1 × (t − (t0 − 1))^v2)`. `t0` is the integer floor of the earliest data year for that country. |
+| **ice_v1, ice_v2, ice_t0** | Same shape, fit independently on the ICE share. |
+| **verschiebung** | Internal R variable for `t0`. Historical name kept because the math comes from a German R script and renaming it would obscure the byte-for-byte invariant. |
+| **extrapol** | The integer year the regression extrapolates to. Currently 2200, far enough that all countries cross every meaningful threshold. |
+| **confidence_level** | `0.999` — used for the BEV/ICE confidence ribbons on the trajectory plots. |
+| **weight** | In `weights.csv`, the trailing 12-month sum of TOTAL for monthly countries (or trailing-4-quarter sum, or last-yearly). Used as a country importance weight in cross-country aggregates. |
+
+## Architecture / deployment
+
+| Term | Meaning |
+|---|---|
+| **Worker** | Cloudflare Workers runtime instance running `worker/index.js`. Single deployed unit. |
+| **Action** | A GitHub Actions workflow defined in `.github/workflows/*.yml`. We have two: `render-country` (manual) and `build-manifest` (push-triggered). |
+| **PAT** | Personal Access Token. The Worker holds a fine-grained PAT scoped to this one repo. |
+| **KV** | Cloudflare KV, a key-value store. Used only for rate-limit counters. |
+| **Pages** | GitHub Pages, the static-site hosting that serves `index.html` and friends. |
+| **manifest** | `manifest.json` at repo root, listing every PNG in `images/`. Built by `build_manifest.R`. |
+| **upsert** | Insert-or-update by key. `(country, variant)` for params/weights; `(period, variant)` for `data/<Country>.csv` rows. |
+| **honeypot** | A hidden form field that humans never fill but bots auto-populate. Submissions with a non-empty honeypot are silently dropped (response 200 to fool the bot). |
+| **rate-limit window** | 60 minutes (`RATE_LIMIT_WINDOW`). Each IP can submit at most `RATE_LIMIT_MAX = 3` of either `/issues` or `/submissions` in that window. |
+
+## Conventions
+
+| Term | Meaning |
+|---|---|
+| **canonical schema** | The wide-but-sparse fuel-column header that each `data/<Country>.csv` follows. See [03-data-objects.md § 3.1](03-data-objects.md#31-country-raw-data). |
+| **wide-but-sparse** | One row per (period, variant); fuel columns are NA where not reported, never zero-filled. |
+| **line-level upsert** | Modifying just one line of a CSV without round-tripping the whole file through a parser. Used in `R/upsert.R` to keep diffs minimal. |
+| **3-curve rollup** | The aggregation rule for the ICE/BEV/PHEV trajectory plot: BEV / (PHEV + EREV) / (everything else). The "everything else" includes HEV, MHEV, Petrol, Diesel, Gas, OTHERS, and an explicit ICE column if reported. |
+| **byte-identical** | The result of a refit must equal the historical params row to ~1e-7 relative tolerance. Drift larger than that means the math has changed and historical thresholds become non-reproducible. |
+
+## Common abbreviations in commit messages and chat
+
+| Abbrev | Stands for |
+|---|---|
+| **TTM** | Trailing Twelve Months |
+| **EAM** | Enterprise Architecture Management |
+| **EREV / PHEV / HEV / BEV / MHEV / ICE** | (See vehicle categories above) |
+| **PR** | Pull Request |
+| **PAT** | Personal Access Token |
+| **KV** | Cloudflare Key-Value store |
+| **CI** | Continuous Integration (here: GitHub Actions) |
+| **`%p`** | Percentage points — the suffix used in the post text to distinguish a sub-percentage value from a top-level percent (e.g. "63.1% ICE (of which 28.2%p were HEV)") |
+
+## See also
+
+- [01-overview.md](01-overview.md) for the high-level picture
+- [03-data-objects.md](03-data-objects.md) for schema details

--- a/docs/architecture/09-glossary.md
+++ b/docs/architecture/09-glossary.md
@@ -46,7 +46,7 @@ Domain jargon used across the codebase, the data, and the chats. Look here when 
 | **ice_v1, ice_v2, ice_t0** | Same shape, fit independently on the ICE share. |
 | **verschiebung** | Internal R variable for `t0`. Historical name kept because the math comes from a German R script and renaming it would obscure the byte-for-byte invariant. |
 | **extrapol** | The integer year the regression extrapolates to. Currently 2200, far enough that all countries cross every meaningful threshold. |
-| **confidence_level** | `0.999` — used for the BEV/ICE confidence ribbons on the trajectory plots. |
+| **confidence_level** | `0.999` — used to derive the grey/coloured ribbon around each fitted curve. **This is not a true statistical confidence interval.** It is a visual band derived from the fit's standard error scaled by the z-quantile at this level. Useful as a "the curve could plausibly sit anywhere in here" hint, not for rigorous inference. A proper CI is a future improvement. |
 | **weight** | In `weights.csv`, the trailing 12-month sum of TOTAL for monthly countries (or trailing-4-quarter sum, or last-yearly). Used as a country importance weight in cross-country aggregates. |
 
 ## Architecture / deployment

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -56,7 +56,8 @@ flowchart LR
 
     Actions -- "git push" --> Repo
     Repo -- "auto-deploy" --> Pages
-    Repo -- "trigger" --> Actions
+    Repo -- "push to images/** triggers build-manifest" --> Actions
+    Maintainer -- "manual dispatch (render-country)" --> Actions
 
     RStudio -- "git push images, params, posts" --> Repo
 ```

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,79 @@
+# Architecture Handbook
+
+This folder is the reference manual for the LeRaffl Gallery project. It is written for two audiences:
+
+- **Humans** (you, future contributors) who need a fast way to understand or revisit how something works without reading source code.
+- **LLMs** (Claude sessions, Copilot, Cursor) that need grounded context to make sensible suggestions.
+
+It is **not** a tutorial. It documents what exists, why it was built that way, and where to look. Every change to a component, an interface, a secret, an external integration, or a data flow should land in the same PR as the code change that introduces it.
+
+## Index
+
+| # | File | What's in it |
+|---|---|---|
+| 0 | [README.md](README.md) | This file. The map. |
+| 1 | [01-overview.md](01-overview.md) | Project purpose, capabilities, actors, ArchiMate layer view |
+| 2 | [02-components.md](02-components.md) | Application components — what each one does, where it lives, why it exists |
+| 3 | [03-data-objects.md](03-data-objects.md) | All persistent data — schema, owner, lifecycle, where stored |
+| 4 | [04-interfaces.md](04-interfaces.md) | Endpoint contracts and external API surfaces used |
+| 5 | [05-flows.md](05-flows.md) | Sequence diagrams for every meaningful end-to-end flow |
+| 6 | [06-tech-stack.md](06-tech-stack.md) | Languages, runtimes, package matrix |
+| 7 | [07-secrets-trust.md](07-secrets-trust.md) | Secrets, trust boundaries, threat model, rate-limits |
+| 8 | [08-deploy-ops.md](08-deploy-ops.md) | Operational runbook: deploys, triggers, common breakage |
+| 9 | [09-glossary.md](09-glossary.md) | Domain jargon (TTM, EREV, slug, variant, …) |
+
+## Big picture in one diagram
+
+```mermaid
+flowchart LR
+    subgraph Browser
+        Page["Static Page<br/>(index.html)"]
+    end
+
+    subgraph Cloudflare
+        Worker["Edge Worker<br/>leraffl-gallery-feedback"]
+        KV[(RATE_KV)]
+    end
+
+    subgraph GitHub
+        Repo[("Git repo<br/>data/, posts/, images/, R/")]
+        Issues[("Issues")]
+        PRs[("Pull Requests")]
+        Actions["Actions<br/>(render-country, build-manifest)"]
+        Pages["GitHub Pages"]
+    end
+
+    subgraph Maintainer["Maintainer's Mac"]
+        RStudio["RStudio<br/>(legacy local R run)"]
+    end
+
+    Page -- "GET manifest, posts, raw CSVs" --> Pages
+    Page -- "POST /issues, POST /submissions" --> Worker
+    Worker -- "Rate-limit lookup" --> KV
+    Worker -- "REST API (PAT)" --> Issues
+    Worker -- "REST API (PAT)" --> PRs
+    Worker -- "REST API (PAT)" --> Repo
+
+    Actions -- "git push" --> Repo
+    Repo -- "auto-deploy" --> Pages
+    Repo -- "trigger" --> Actions
+
+    RStudio -- "git push images, params, posts" --> Repo
+```
+
+## Mental model in one paragraph
+
+The project is a **publication pipeline**. Country registration data lives in versioned CSVs in the repo. R turns CSVs into PNG charts and parameter rows. A static page renders those PNGs from a JSON manifest. Updates flow either from the maintainer's local R run (legacy, fast iteration) or from public submissions that go through a Cloudflare Worker → PR → review → merge → GitHub Action re-render. Every persistent artefact is a file in Git; the only non-Git state is rate-limit counters in Cloudflare KV.
+
+## When to update these docs
+
+Update the matching chapter in the same PR if your change introduces or modifies:
+- A new application component or runtime → [02-components.md](02-components.md), [06-tech-stack.md](06-tech-stack.md)
+- A new file under `data/`, `posts/`, `images/`, a CSV column, a JSON shape → [03-data-objects.md](03-data-objects.md)
+- A new endpoint, request/response shape, or external API call → [04-interfaces.md](04-interfaces.md)
+- A new user journey or background job → [05-flows.md](05-flows.md)
+- A new secret, scope, or trust boundary → [07-secrets-trust.md](07-secrets-trust.md)
+- A new deploy/operate step the maintainer needs to remember → [08-deploy-ops.md](08-deploy-ops.md)
+- New jargon → [09-glossary.md](09-glossary.md)
+
+If you're not sure where it goes, put it in [01-overview.md](01-overview.md) and we'll re-home it later.


### PR DESCRIPTION
## What this is

A self-contained reference manual for the project at `docs/architecture/`. Written to serve both humans (you, future contributors) and LLMs (Claude, Copilot sessions) as grounded context.

Markdown + inline Mermaid diagrams so everything renders natively on GitHub — no build step, no PDF pipeline, diffs are reviewable line by line. (PDF can be added later via a small pandoc Action if you ever want a print artefact; not in this PR.)

## Structure

| File | Pages of content | What's in it |
|---|---|---|
| `README.md` | ~80 lines | Index + the one big-picture diagram + when-to-update rules |
| `01-overview.md` | ~120 | Purpose, capabilities, actors, ArchiMate layer view |
| `02-components.md` | ~270 | Every application component with rationale ("why this shape") |
| `03-data-objects.md` | ~340 | Schema, owner, lifecycle for every persistent file |
| `04-interfaces.md` | ~300 | Worker endpoint contracts and external API surfaces |
| `05-flows.md` | ~275 | 7 sequence diagrams covering every meaningful user journey |
| `06-tech-stack.md` | ~110 | Language/runtime/package matrix |
| `07-secrets-trust.md` | ~125 | Secret inventory, threat model, rotation playbook |
| `08-deploy-ops.md` | ~205 | Operational runbook with copy-pasteable commands |
| `09-glossary.md` | ~95 | Domain jargon (TTM, EREV, slug, variant, …) |

15 Mermaid diagrams total: layer view, component map, trust boundaries, 7 sequence diagrams, plus per-chapter inline diagrams.

## Maintenance rule

`docs/architecture/README.md` lists which chapter to update for which kind of change. The intent is: the same PR that introduces a new component / endpoint / secret / data object also updates the matching chapter. Soft enforcement, not a CI gate — but easy to flag in review.

## Top-level `README.md`

Gets one new line in the repo-structure table pointing to `docs/architecture/`.

## What's deliberately NOT in here

- Tokens, account IDs, KV namespace IDs — those live only in Cloudflare/GitHub settings or `wrangler.toml`. The doc only describes "what kind of credential" and "where it lives".
- A pandoc PDF Action — pure-text-and-diagrams Markdown was the brief. Easy to add later.
- A CONTRIBUTING.md — not yet useful as a one-maintainer project.

## Test plan
- [ ] Open `docs/architecture/README.md` in the GitHub web UI and confirm Mermaid diagrams render (they will — GitHub native).
- [ ] Skim each chapter for accuracy; flag anything that doesn't match how you remember it.
- [ ] Try giving an LLM (e.g. fresh Claude Code session) a single file and asking "what does this project do?" — answer should be coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)