### PR TITLE
data: Australia (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/Australia.csv
+++ b/data/Australia.csv
@@ -73,3 +73,4 @@ period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,note
 2026-01,monthly,Whole,VFACTS & Prof. Ray Willis,7409.0,5161.0,15131.0,33144.0,24439.0,,85284.0,
 2026-02,monthly,Whole,VFACTS & Prof. Ray Willis,11134.0,5854.0,13868.0,33309.0,26963.0,,91128.0,
 2026-03,monthly,Whole,VFACTS & Prof. Ray Willis,15839.0,8215.0,17953.0,34694.0,28364.0,,105065.0,
+2026-04,monthly,Whole,VFACTS & Prof. Ray Willis,15459,9628,18162,25399,22414,,91062,Check again for consistency


### PR DESCRIPTION
Submitted by **LeRaffl** via Submit Data form.

- **Country:** Australia
- **Variant:** Whole
- **Source:** VFACTS & Prof. Ray Willis
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-04** (monthly) — BEV=15459, PHEV=9628, HEV=18162, PETROL=25399, DIESEL=22414, TOTAL=91062

---

After merge, trigger the **Render country charts** Action to regenerate plots.