### PR TITLE
data: Italy (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/Italy.csv
+++ b/data/Italy.csv
@@ -134,3 +134,4 @@ period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,note
 2026-01,monthly,Whole,unrae.it,9446.0,12502.0,74742.0,26806.0,10490.0,9346.0,143332.0,
 2026-02,monthly,Whole,unrae.it,12572.0,13525.0,82315.0,32012.0,10278.0,8008.0,158710.0,
 2026-03,monthly,Whole,unrae.it,16137.0,16998.0,93652.0,37678.0,12150.0,10073.0,186688.0,
+2026-04,monthly,Whole,unrae.it,13238,14184,76808,31850,10718,9550,156348,https://unrae.it/dati-statistici/immatricolazioni/7623/struttura-del-mercato-aprile-2026


### PR DESCRIPTION
Submitted by **LeRaffl** via Submit Data form.

- **Country:** Italy
- **Variant:** Whole
- **Source:** unrae.it
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-04** (monthly) — BEV=13238, PHEV=14184, HEV=76808, PETROL=31850, DIESEL=10718, OTHERS=9550, TOTAL=156348

---

After merge, trigger the **Render country charts** Action to regenerate plots.