### PR TITLE
Clarify GitHub Pages deployment and include posts in render workflow

### DIFF
--- a/.github/workflows/render-country.yml
+++ b/.github/workflows/render-country.yml
@@ -57,5 +57,6 @@ jobs:
             images
             params.csv
             weights.csv
+            posts
           message: "chore: render ${{ inputs.country }} (${{ inputs.variant }})"
           default_author: github_actions

--- a/docs/architecture/05-flows.md
+++ b/docs/architecture/05-flows.md
@@ -92,7 +92,7 @@ sequenceDiagram
     Pages->>Pages: serve updated assets
 ```
 
-After this, Flow E (manifest rebuild) is auto-triggered by the push to `images/**`.
+After this, Flow E (manifest rebuild) is auto-triggered by the push to `images/**`. The manifest commit then pushes to `master`, which GitHub Pages auto-deploys (Pages-from-branch; no separate Pages workflow exists or is needed).
 
 **Performance notes:**
 - Cold runner: ~2 min including R-package install

--- a/docs/architecture/08-deploy-ops.md
+++ b/docs/architecture/08-deploy-ops.md
@@ -55,7 +55,7 @@ Steps:
 4. Fill `country` (e.g. `Germany`) and `variant` (default `Whole`)
 5. Click "Run workflow"
 
-The action takes 30–120 s and commits four PNGs + params/weights row update + posts files. The Build-manifest action triggers automatically on the resulting `images/**` push.
+The action takes 30–120 s and commits four PNGs + params/weights row update + posts files. The Build-manifest action triggers automatically on the resulting `images/**` push. GitHub Pages then auto-deploys from `master` (Pages-from-branch — there is no separate Pages workflow).
 
 **You can also trigger via gh CLI:**
 ```bash


### PR DESCRIPTION
## Summary
This PR updates documentation and workflow configuration to clarify the GitHub Pages deployment process and ensure all generated artifacts are committed during country rendering.

## Key Changes
- **Documentation updates** (`docs/architecture/05-flows.md` and `docs/architecture/08-deploy-ops.md`): Added explicit clarification that GitHub Pages auto-deploys from the `master` branch using the Pages-from-branch feature, with no separate Pages workflow required
- **Workflow configuration** (`render-country.yml`): Added `posts` directory to the list of paths committed by the render-country workflow, ensuring generated posts are included alongside images and parameter files

## Implementation Details
- The documentation now clearly explains the deployment flow: manifest rebuild on `images/**` push → manifest commit to `master` → automatic GitHub Pages deployment
- The render-country workflow now commits four artifacts: PNGs, params.csv, weights.csv, and posts directory
- This ensures consistency between what the workflow generates and what gets persisted to the repository

https://claude.ai/code/session_01LGYP34rYmgxqd5VCcA3Fuv