### PR TITLE
[codex] Dispatch manifest build after render

### DIFF
--- a/.github/workflows/render-country.yml
+++ b/.github/workflows/render-country.yml
@@ -3,7 +3,7 @@ name: Render country charts
 # Manual trigger from the Actions UI. After data/<Country>.csv is updated
 # (typically via a merged Submit-Data PR), pick the country here and the
 # four PNGs + params.csv + weights.csv are regenerated and committed.
-# The Build manifest workflow then picks up the new images automatically.
+# The Build manifest workflow is dispatched after the render commit.
 
 on:
   workflow_dispatch:
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     concurrency:
       group: render-${{ inputs.country }}-${{ inputs.variant }}
       cancel-in-progress: false
@@ -60,3 +61,9 @@ jobs:
             posts
           message: "chore: render ${{ inputs.country }} (${{ inputs.variant }})"
           default_author: github_actions
+
+      - name: Trigger manifest build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run build-manifest.yml --ref "${GITHUB_REF_NAME}"

--- a/docs/architecture/02-components.md
+++ b/docs/architecture/02-components.md
@@ -199,6 +199,7 @@ A GitHub Action with `workflow_dispatch` only — it runs only when manually tri
 3. Installs the R package set (ggplot2, scales, grid, png, ggtext, viridis, showtext, sysfonts, glue) with apt prebuilds
 4. Runs `Rscript R/render_country.R <country> <variant>`
 5. Commits the resulting `images/<period>/*.png`, `params.csv` row update, `weights.csv` row update, `posts/<slug>.txt`, `posts/<slug>_<period>.txt` via `EndBug/add-and-commit`
+6. Dispatches `build-manifest.yml` explicitly so the generated images are indexed immediately
 
 ### Why manual trigger only and not on `data/` push?
 
@@ -217,7 +218,7 @@ A GitHub Action that rebuilds `manifest.json` whenever PNG files change.
 - Push to `images/**` (any new/deleted/renamed image)
 - Push to `build_manifest.R` (the builder itself changed)
 - Daily cron at 03:17 UTC as a self-healing fallback
-- Manual dispatch
+- Manual dispatch, including the explicit dispatch from Render-country after a successful render commit
 
 ### Why the cron?
 

--- a/docs/architecture/05-flows.md
+++ b/docs/architecture/05-flows.md
@@ -87,12 +87,13 @@ sequenceDiagram
     Runner->>Repo: git add images/ params.csv weights.csv posts/
     Runner->>Repo: git commit -m "chore: render Germany (Whole)"
     Runner->>Repo: git push origin master
+    Runner->>Repo: gh workflow run build-manifest.yml
 
     Repo->>Pages: deploy hook
     Pages->>Pages: serve updated assets
 ```
 
-After this, Flow E (manifest rebuild) is auto-triggered by the push to `images/**`. The manifest commit then pushes to `master`, which GitHub Pages auto-deploys (Pages-from-branch; no separate Pages workflow exists or is needed).
+After this, Flow E (manifest rebuild) is explicitly dispatched by the Render-country workflow. Direct maintainer pushes to `images/**` still trigger Flow E through the path filter. The manifest commit then pushes to `master`, which GitHub Pages auto-deploys (Pages-from-branch; no separate Pages workflow exists or is needed).
 
 **Performance notes:**
 - Cold runner: ~2 min including R-package install
@@ -171,7 +172,7 @@ sequenceDiagram
     participant Action as Build-manifest Action
     participant Runner as Action Runner
 
-    Note over Repo,Action: Trigger sources (any one of):<br/>• push to images/**<br/>• push to build_manifest.R<br/>• daily cron 03:17 UTC<br/>• manual workflow_dispatch
+    Note over Repo,Action: Trigger sources (any one of):<br/>• Render-country explicit dispatch<br/>• push to images/**<br/>• push to build_manifest.R<br/>• daily cron 03:17 UTC<br/>• manual workflow_dispatch
     Repo->>Action: workflow trigger
     Action->>Runner: dispatch
     Runner->>Repo: checkout

--- a/docs/architecture/08-deploy-ops.md
+++ b/docs/architecture/08-deploy-ops.md
@@ -55,7 +55,7 @@ Steps:
 4. Fill `country` (e.g. `Germany`) and `variant` (default `Whole`)
 5. Click "Run workflow"
 
-The action takes 30–120 s and commits four PNGs + params/weights row update + posts files. The Build-manifest action triggers automatically on the resulting `images/**` push. GitHub Pages then auto-deploys from `master` (Pages-from-branch — there is no separate Pages workflow).
+The action takes 30–120 s and commits four PNGs + params/weights row update + posts files. It then dispatches the Build-manifest action explicitly, because workflow commits made with `GITHUB_TOKEN` do not fan out into another push-triggered workflow. GitHub Pages auto-deploys from `master` after each generated commit (Pages-from-branch — there is no separate Pages workflow).
 
 **You can also trigger via gh CLI:**
 ```bash


### PR DESCRIPTION
## Summary
- dispatch `build-manifest.yml` explicitly after `Render country charts` commits outputs
- grant the render job `actions: write` so `GITHUB_TOKEN` can create the workflow dispatch
- update the architecture/runbook docs to reflect the explicit dispatch path

## Why
Render commits created with `GITHUB_TOKEN` do not trigger another push-based workflow, so the manifest build could be skipped unless run manually or by the cron fallback.

## Checks
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/render-country.yml'); puts 'YAML OK'"`\n- `git diff --check -- .github/workflows/render-country.yml docs/architecture/02-components.md docs/architecture/05-flows.md docs/architecture/08-deploy-ops.md`