### PR TITLE
chore: ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ images/2025-10/germany_ICE_BEV_20251129.png
 images/2025-10/germany_time_20251129.png
 images/2025-10/germany_ttm_shares_20251129.png
 .DS_Store
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Adds `.claude/worktrees/` to `.gitignore` so local Claude Code worktree mounts can't be accidentally committed.
- Prevents a recurrence of the path-mixup fixed in #24.

## Test plan
- [ ] After merge, `git status` in a worktree-using checkout no longer lists `.claude/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)