### PR TITLE
fix(brazil): set browser User-Agent for ANFAVEA scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Key files in the repository root:
 | **images/** | Contains all exported PNG files structured as `images/YYYY-MM/...`. GitHub Pages serves them directly. |
 | **.github/workflows/build-manifest.yml** | CI workflow ensuring that `manifest.json` always stays up to date. |
 | **docs/architecture/** | Architecture handbook — components, data objects, interfaces, flows, secrets, ops. Kept up to date with every PR that changes structure. Start at [docs/architecture/README.md](docs/architecture/README.md). |
+| **scripts/fetch_brazil.py** | Automated data ingestion for Brazil. Scrapes the ANFAVEA xlsx for the current year, parses sheet "III. Emplacamento Combustível" (cars + light commercial, Unidades table), and upserts new monthly rows into `data/Brazil.csv`. Full parsing logic & column mapping documented in the module docstring. |
+| **.github/workflows/fetch-brazil.yml** | Runs `fetch_brazil.py` on the 10th of each month (08:00 UTC) and on manual dispatch. If `data/Brazil.csv` changes, the workflow commits it and triggers `render-country.yml` with `country=Brazil`. |
 
 ---
 

--- a/docs/architecture/05-flows.md
+++ b/docs/architecture/05-flows.md
@@ -13,6 +13,7 @@ End-to-end sequence diagrams for every meaningful user journey or background pro
 | E | [Auto-rebuild manifest](#flow-e--manifest-rebuild) | Push to images/** or daily cron | Updated manifest.json |
 | F | [Visitor reads gallery](#flow-f--gallery-read) | Page load on leraffl.github.io | Manifest + images displayed |
 | G | [Copy post text](#flow-g--copy-post) | Click "📋 Copy post" or run Apple Shortcut | Text in clipboard |
+| H | [Auto-ingest Brazil from ANFAVEA](#flow-h--anfavea-ingest) | Monthly cron (10th, 08:00 UTC) or manual dispatch | Updated `data/Brazil.csv` → triggers Flow B for Brazil |
 
 ---
 
@@ -257,6 +258,43 @@ sequenceDiagram
 ```
 
 **Why two paths to the same artefact:** the in-page button is for visitors and casual mobile/desktop use; the Shortcut is for the maintainer's posting workflow on iOS where launching Safari is more friction than tapping a Shortcut on the home screen.
+
+## Flow H — ANFAVEA ingest
+
+Brazil is the first country with an automated, source-side ingestion. ANFAVEA publishes one Excel workbook per year (`siteautoveiculos<YEAR>.xlsx`) covering production, registrations, exports, and employment. We only consume sheet "III. Emplacamento Combustível" — the cars + light-commercial fuel-split table.
+
+```mermaid
+sequenceDiagram
+    participant Cron as GitHub Actions (cron / dispatch)
+    participant Job as fetch-brazil.yml job
+    participant Site as anfavea.com.br
+    participant CSV as data/Brazil.csv
+    participant Render as render-country.yml
+
+    Cron->>Job: workflow_dispatch OR cron (10th 08:00 UTC)
+    Job->>Site: GET /site/edicoes-em-excel/ (browser UA)
+    Site-->>Job: HTML index
+    Job->>Job: regex match siteautoveiculos<year>(-N)?.xlsx
+    Job->>Site: GET /docs/siteautoveiculos<year>.xlsx
+    Site-->>Job: xlsx bytes
+    Job->>Job: Open sheet "III. Emplacamento Combustível"<br/>locate "Unidades" header → month row → fuel rows
+    Job->>Job: Map Portuguese fuel labels → CSV columns<br/>(Elétrico→BEV, Híbrido Plug-in→PHEV, Híbrido→HEV,<br/>Gasolina→PETROL, Diesel→DIESEL, Flex Fuel→FLEXFUEL)
+    Job->>Job: Skip months where all fuel values are 0
+    Job->>CSV: Upsert by period; warn on >50% delta vs existing
+    alt CSV changed
+        Job->>Render: gh workflow run render-country.yml -f country=Brazil
+    else No change
+        Job-->>Cron: Exit cleanly, nothing committed
+    end
+```
+
+**Where parsing lives:** [scripts/fetch_brazil.py](../../scripts/fetch_brazil.py). The module docstring is the authoritative reference for the parsing rules, column map, and how the script handles partial-year data.
+
+**Why a browser User-Agent:** ANFAVEA's Apache returns HTTP 406 for `python-requests/*`. We send a Chrome desktop UA + standard `Accept` / `Accept-Language` headers on both calls.
+
+**Why not the trucks/buses table:** sheet III has a second "Caminhões e Ônibus" block below the cars block. It uses a different fuel taxonomy (Elétrico/Gás/Diesel only) and isn't represented in `data/Brazil.csv`'s schema. The parser only walks the FIRST "Unidades" header and stops at the closing "Fonte:" marker, so the trucks table is naturally skipped.
+
+**Adding more countries:** the pattern (`fetch-<country>.yml` → `scripts/fetch_<country>.py` → commit + dispatch render) is intentionally country-local rather than generic, because each statistics agency has its own URL scheme, file layout, and quirks. Duplicate and adapt rather than parameterise prematurely.
 
 ## See also
 

--- a/scripts/fetch_brazil.py
+++ b/scripts/fetch_brazil.py
@@ -2,12 +2,93 @@
 """
 Fetch Brazil vehicle registration data from ANFAVEA and update data/Brazil.csv.
 
-Usage:
+Usage
+-----
     python scripts/fetch_brazil.py [--url URL] [--year YEAR] [--csv PATH]
 
-If --url is omitted, the script scrapes the ANFAVEA page to find the Excel
-file URL for the given year (default: current year). --url also accepts a
-local file path for testing (e.g. --url /path/to/file.xlsx).
+* --url   Direct Excel URL or local file path. If omitted, the ANFAVEA
+          index page is scraped for the current year's file.
+* --year  Override the year (default: current calendar year).
+* --csv   Target CSV (default: data/Brazil.csv).
+
+This script is invoked by .github/workflows/fetch-brazil.yml on a monthly
+cron (10th, 08:00 UTC) and via manual workflow_dispatch. When it produces
+changes, the workflow commits data/Brazil.csv and triggers render-country.yml
+for Brazil.
+
+Data source
+-----------
+ANFAVEA (Associação Nacional dos Fabricantes de Veículos Automotores) publishes
+one Excel workbook per year at https://anfavea.com.br/site/edicoes-em-excel/.
+The canonical filename is `siteautoveiculos<YEAR>.xlsx`; mid-year revisions
+may add a `-N` suffix. ANFAVEA also publishes `_nacionais` and `_importados`
+splits — we explicitly ignore those (regex in `find_excel_url`) and parse
+only the combined total file.
+
+Parsing strategy
+----------------
+We read sheet "III. Emplacamento Combustível", which contains two tables:
+
+  1. "Automóveis e Comerciais Leves" (cars + light commercial) — WE PARSE THIS
+  2. "Caminhões e Ônibus" (trucks + buses) — IGNORED for now
+
+Each table is laid out as:
+
+    | <category> | <metric type> | Jan | Fev | Mar | ... | Dez | Total Ano |
+    | Gasolina   |               | 6222| 5856| ...
+    | Elétrico   |               | 8313| 8738| ...
+    | ...
+
+Row positions shift slightly year to year, so we locate the table dynamically:
+
+  1. Find the FIRST row that contains the literal cell value "Unidades"
+     (= the units sub-header of the cars table; "Porcenrtagem" [sic] marks
+     the percentage table below it which we skip).
+  2. The row immediately below that holds the month abbreviations
+     (Jan, Fev, Mar, Abr, Mai, Jun, Jul, Ago, Set, Out, Nov, Dez). We build
+     a {month_abbrev → column_index} map from whatever columns contain those
+     strings, so layout changes don't break us.
+  3. We then walk subsequent rows reading the fuel name from column B (or C
+     as a fallback), looking it up in FUEL_MAP. Reading stops as soon as we
+     hit a row containing "Fonte:" — that's the ANFAVEA end-of-table marker.
+
+Column mapping (Portuguese → CSV column)
+----------------------------------------
+    Elétrico         → BEV
+    Híbrido Plug-in  → PHEV
+    Híbrido          → HEV         (regular non-plug-in hybrids)
+    Gasolina         → PETROL
+    Diesel           → DIESEL
+    Flex Fuel        → FLEXFUEL    (Brazil-specific: gasoline + ethanol)
+    (none)           → OTHERS = 0  (always zero for Brazil)
+    sum of all above → TOTAL
+
+Months without published data
+-----------------------------
+ANFAVEA pre-fills the entire calendar year with zeros and overwrites
+month-by-month as data becomes available. We skip any month where ALL fuel
+values are zero — that lets the script run mid-year without producing fake
+"all-zero" rows for future months.
+
+Upsert + plausibility check
+---------------------------
+Existing rows in data/Brazil.csv are keyed by `period` (YYYY-MM). For each
+month parsed:
+
+  * If the period is missing, we append a new row.
+  * If it exists, we overwrite the row, but emit a WARNING to stdout if any
+    fuel-type value moved by more than 50% versus the previous value — a
+    cheap guard against parser drift or upstream relabeling.
+
+The CSV is rewritten sorted by period. The `notes` field on touched rows
+records the source filename (e.g. "siteautoveiculos2026.xlsx") for
+provenance.
+
+HTTP details
+------------
+ANFAVEA's Apache returns HTTP 406 Not Acceptable to the default
+python-requests User-Agent, so we send desktop-Chrome headers (see
+HTTP_HEADERS below) on both the page scrape and the xlsx download.
 """
 import argparse
 import csv

--- a/scripts/fetch_brazil.py
+++ b/scripts/fetch_brazil.py
@@ -13,6 +13,7 @@ import argparse
 import csv
 import io
 import os
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -23,6 +24,18 @@ from bs4 import BeautifulSoup
 
 ANFAVEA_PAGE = "https://anfavea.com.br/site/edicoes-em-excel/"
 TARGET_SHEET = "III. Emplacamento Combustível"
+
+# ANFAVEA's Apache returns HTTP 406 for the default python-requests UA,
+# so we identify as a regular desktop browser.
+HTTP_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "pt-BR,pt;q=0.9,en;q=0.8",
+}
 CSV_COLUMNS = [
     "period", "time_interval", "variant", "source",
     "BEV", "PHEV", "HEV", "PETROL", "DIESEL", "FLEXFUEL",
@@ -44,21 +57,21 @@ MONTH_ABR = ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun",
 
 
 def find_excel_url(year: int) -> str:
-    """Scrape the ANFAVEA page and return the xlsx URL for the given year."""
-    resp = requests.get(ANFAVEA_PAGE, timeout=30)
+    """Scrape the ANFAVEA page and return the xlsx URL for the given year.
+
+    Prefers the canonical "siteautoveiculos<year>(-N)?.xlsx" (total file)
+    over the "_nacionais" / "_importados" splits.
+    """
+    resp = requests.get(ANFAVEA_PAGE, headers=HTTP_HEADERS, timeout=30)
     resp.raise_for_status()
     soup = BeautifulSoup(resp.text, "html.parser")
-    year_str = str(year)
 
+    # Matches siteautoveiculos2026.xlsx and siteautoveiculos2026-2.xlsx,
+    # but NOT siteautoveiculos_nacionais2026.xlsx (digit must follow directly).
+    pattern = re.compile(rf"siteautoveiculos{year}(?:[-_]\d+)?\.xlsx", re.IGNORECASE)
     for a in soup.find_all("a", href=True):
         href = a["href"]
-        if "siteautoveiculos" in href.lower() and year_str in href:
-            return href if href.startswith("http") else "https://anfavea.com.br" + href
-
-    # Fallback: any .xlsx link whose text contains the year
-    for a in soup.find_all("a", href=True):
-        href = a["href"]
-        if href.lower().endswith(".xlsx") and year_str in (a.get_text() + href):
+        if pattern.search(href):
             return href if href.startswith("http") else "https://anfavea.com.br" + href
 
     raise RuntimeError(
@@ -71,7 +84,7 @@ def load_workbook_bytes(url_or_path: str) -> tuple[bytes, str]:
     """Return (file_bytes, source_filename). Accepts http(s) URL or local path."""
     if url_or_path.startswith("http://") or url_or_path.startswith("https://"):
         print(f"Downloading: {url_or_path}")
-        resp = requests.get(url_or_path, timeout=60)
+        resp = requests.get(url_or_path, headers=HTTP_HEADERS, timeout=60)
         resp.raise_for_status()
         return resp.content, url_or_path.split("/")[-1]
     path = url_or_path.replace("file://", "")


### PR DESCRIPTION
## Summary

Fixes the failed live run + adds proper documentation so we remember how the parsing works.

### Bug fix
- The first live run of `fetch-brazil.yml` failed with `HTTP 406 Not Acceptable` because ANFAVEA's Apache rejects the default `python-requests/*` User-Agent.
- Adds a desktop-Chrome UA + standard `Accept` / `Accept-Language` headers, applied to both the page scrape and the xlsx download.
- Replaces the loose substring match with a regex anchored to `siteautoveiculos<year>(-N)?.xlsx`, so the canonical total file wins over `_nacionais` / `_importados` splits that ANFAVEA also publishes.

### Documentation
Three layers, all in this PR:

1. **[scripts/fetch_brazil.py](../blob/fix/anfavea-user-agent/scripts/fetch_brazil.py)** — full module docstring covering the data source, dynamic table-location strategy (why we search for "Unidades" instead of hard-coding row numbers), Portuguese→CSV fuel-column mapping, zero-month skipping, upsert + plausibility check, and the HTTP-406 workaround.
2. **[README.md](../blob/fix/anfavea-user-agent/README.md)** — two new rows in the repo-structure table pointing at the script and its workflow.
3. **[docs/architecture/05-flows.md](../blob/fix/anfavea-user-agent/docs/architecture/05-flows.md)** — new "Flow H · ANFAVEA ingest" with a mermaid sequence diagram of the cron → scrape → parse → upsert → dispatch-render chain. Includes notes on why we ignore the trucks/buses table and why each country gets its own script rather than a generic ingester.

## Verification

Ran the script end-to-end locally (no `--url` override) — the auto-discovery now works against the live page:

```
Searching for 2026 Excel on ANFAVEA page …
Found: https://anfavea.com.br/docs/siteautoveiculos2026.xlsx
Parsed 4 months: ['2026-01', '2026-02', '2026-03', '2026-04']
Done: 4 rows added, 0 rows updated
```

## Test plan
- [ ] After merge, manual `workflow_dispatch` on `fetch-brazil.yml` (no inputs) succeeds
- [ ] If `data/Brazil.csv` gets new rows, `render-country.yml` for Brazil is triggered automatically
- [ ] Mermaid diagram in `05-flows.md` renders on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)