### PR TITLE
feat(chile): auto-ingest ANAC monthly registration data

### DIFF
--- a/.github/workflows/fetch-chile.yml
+++ b/.github/workflows/fetch-chile.yml
@@ -1,0 +1,85 @@
+name: Fetch Chile data (ANAC)
+
+# Scrapes the latest ANAC PDFs (Mercado Automotor + Cero y Bajas Emisiones)
+# and upserts the most recent month into data/Chile.csv. Runs daily from
+# the 14th of each month onward — the script self-throttles via the latest
+# period already present in the CSV, so most invocations are a no-op until
+# both PDFs for the target month are published.
+# When the CSV changes, render-country.yml is dispatched for Chile.
+
+on:
+  workflow_dispatch:
+    inputs:
+      year:
+        description: 'Target year (leave empty for previous calendar month)'
+        required: false
+        default: ''
+      month:
+        description: 'Target month 1-12 (leave empty for previous calendar month)'
+        required: false
+        default: ''
+      mercado_url:
+        description: 'Direct Mercado Automotor PDF URL (leave empty to auto-discover)'
+        required: false
+        default: ''
+      emisiones_url:
+        description: 'Direct Cero y Bajas Emisiones PDF URL (leave empty to auto-discover)'
+        required: false
+        default: ''
+      force:
+        description: 'Re-process even if target period already exists'
+        required: false
+        default: 'false'
+        type: boolean
+  schedule:
+    - cron: '0 8 14-31 * *'   # 14th through end of month at 08:00 UTC
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install requests beautifulsoup4 pypdf cryptography
+
+      - name: Fetch & update Chile.csv
+        run: |
+          python scripts/fetch_chile.py \
+            ${YEAR:+--year "$YEAR"} \
+            ${MONTH:+--month "$MONTH"} \
+            ${MERCADO_URL:+--mercado-url "$MERCADO_URL"} \
+            ${EMISIONES_URL:+--emisiones-url "$EMISIONES_URL"} \
+            ${FORCE:+--force}
+        env:
+          YEAR: ${{ inputs.year }}
+          MONTH: ${{ inputs.month }}
+          MERCADO_URL: ${{ inputs.mercado_url }}
+          EMISIONES_URL: ${{ inputs.emisiones_url }}
+          FORCE: ${{ inputs.force == true && '1' || '' }}
+
+      - name: Commit if changed
+        id: commit
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: data/Chile.csv
+          message: 'chore: update Chile data from ANAC'
+          default_author: github_actions
+
+      - name: Trigger render for Chile
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run render-country.yml \
+            --ref "${GITHUB_REF_NAME}" \
+            -f country=Chile \
+            -f variant=Whole

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ images/2025-10/germany_time_20251129.png
 images/2025-10/germany_ttm_shares_20251129.png
 .DS_Store
 .claude/worktrees/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Key files in the repository root:
 | **docs/architecture/** | Architecture handbook — components, data objects, interfaces, flows, secrets, ops. Kept up to date with every PR that changes structure. Start at [docs/architecture/README.md](docs/architecture/README.md). |
 | **scripts/fetch_brazil.py** | Automated data ingestion for Brazil. Scrapes the ANFAVEA xlsx for the current year, parses sheet "III. Emplacamento Combustível" (cars + light commercial, Unidades table), and upserts new monthly rows into `data/Brazil.csv`. Full parsing logic & column mapping documented in the module docstring. |
 | **.github/workflows/fetch-brazil.yml** | Runs `fetch_brazil.py` on the 10th of each month (08:00 UTC) and on manual dispatch. If `data/Brazil.csv` changes, the workflow commits it and triggers `render-country.yml` with `country=Brazil`. |
+| **scripts/fetch_chile.py** | Automated data ingestion for Chile. Discovers the latest ANAC PDFs (Mercado Automotor + Cero y Bajas Emisiones) for the previous calendar month, parses TOTAL from the bar chart and BEV/PHEV/HEV from the summary table, and writes the new row to `data/Chile.csv` only when both PDFs are available. Self-throttles via the CSV's latest period. |
+| **.github/workflows/fetch-chile.yml** | Runs `fetch_chile.py` daily from the 14th of each month (08:00 UTC) and on manual dispatch — most runs are no-ops until ANAC publishes both PDFs. If `data/Chile.csv` changes, the workflow commits it and triggers `render-country.yml` with `country=Chile`. |
 
 ---
 

--- a/docs/architecture/05-flows.md
+++ b/docs/architecture/05-flows.md
@@ -14,6 +14,7 @@ End-to-end sequence diagrams for every meaningful user journey or background pro
 | F | [Visitor reads gallery](#flow-f--gallery-read) | Page load on leraffl.github.io | Manifest + images displayed |
 | G | [Copy post text](#flow-g--copy-post) | Click "📋 Copy post" or run Apple Shortcut | Text in clipboard |
 | H | [Auto-ingest Brazil from ANFAVEA](#flow-h--anfavea-ingest) | Monthly cron (10th, 08:00 UTC) or manual dispatch | Updated `data/Brazil.csv` → triggers Flow B for Brazil |
+| I | [Auto-ingest Chile from ANAC](#flow-i--anac-ingest) | Daily cron (14th–end of month, 08:00 UTC) or manual dispatch | Updated `data/Chile.csv` → triggers Flow B for Chile |
 
 ---
 
@@ -295,6 +296,43 @@ sequenceDiagram
 **Why not the trucks/buses table:** sheet III has a second "Caminhões e Ônibus" block below the cars block. It uses a different fuel taxonomy (Elétrico/Gás/Diesel only) and isn't represented in `data/Brazil.csv`'s schema. The parser only walks the FIRST "Unidades" header and stops at the closing "Fonte:" marker, so the trucks table is naturally skipped.
 
 **Adding more countries:** the pattern (`fetch-<country>.yml` → `scripts/fetch_<country>.py` → commit + dispatch render) is intentionally country-local rather than generic, because each statistics agency has its own URL scheme, file layout, and quirks. Duplicate and adapt rather than parameterise prematurely.
+
+## Flow I — ANAC ingest
+
+Chile follows the same `fetch-<country>` pattern as Brazil, with one twist: ANAC publishes **two** PDFs per month and they don't appear at the same time. The cron runs daily from the 14th onward and the script self-throttles via the CSV's latest period — most invocations are a no-op.
+
+```mermaid
+sequenceDiagram
+    participant Cron as GitHub Actions (cron / dispatch)
+    participant Job as fetch-chile.yml job
+    participant Site as anac.cl
+    participant CSV as data/Chile.csv
+    participant Render as render-country.yml
+
+    Cron->>Job: workflow_dispatch OR cron (daily 14–31, 08:00 UTC)
+    Job->>CSV: read latest period
+    alt Latest period ≥ target month
+        Job-->>Cron: Exit cleanly (no-op)
+    else Target month missing
+        Job->>Site: GET /category/estudio-de-mercado/ (browser UA)
+        Site-->>Job: HTML listing PDFs
+        alt Either PDF missing
+            Job-->>Cron: Exit cleanly (no-op, retry tomorrow)
+        else Both PDFs present
+            Job->>Site: GET Mercado Automotor + Cero y Bajas Emisiones PDFs
+            Site-->>Job: PDF bytes
+            Job->>Job: Parse TOTAL + BEV/PHEV/HEV via pypdf
+            Job->>CSV: Append target-month row (ICE = TOTAL − BEV − PHEV − HEV)
+            Job->>Render: gh workflow run render-country.yml -f country=Chile
+        end
+    end
+```
+
+**Where parsing lives:** [scripts/fetch_chile.py](../../scripts/fetch_chile.py). The module docstring documents the regex patterns, the MHEV-into-ICE convention, and the no-partial-writes rule.
+
+**Why two PDFs:** ANAC splits the headline market total (Mercado Automotor) from the alternative-drivetrain breakdown (Cero y Bajas Emisiones). Both are needed to fill one CSV row; partial writes would produce wrong charts because BEV/PHEV/HEV would default to 0 and inflate ICE.
+
+**Why MHEV → ICE:** ANAC reports mild-hybrids (Microhíbridos) as a separate line that didn't exist historically and isn't in `data/Chile.csv`'s schema. Per maintainer's call we bucket them into ICE via the implicit subtraction (`ICE = TOTAL − BEV − PHEV − HEV − OTHERS`) rather than introducing a new column.
 
 ## See also
 

--- a/docs/architecture/05-flows.md
+++ b/docs/architecture/05-flows.md
@@ -330,6 +330,8 @@ sequenceDiagram
 
 **Where parsing lives:** [scripts/fetch_chile.py](../../scripts/fetch_chile.py). The module docstring documents the regex patterns, the MHEV-into-ICE convention, and the no-partial-writes rule.
 
+**Vehicle scope:** ANAC's "livianos y medianos" covers passenger cars + SUVs + pickups + light commercial vehicles up to 3.860 kg GVWR per DS N°241/2014 (light <2.7 t, medium 2.7–3.86 t). Camiones and buses are excluded. See [09-glossary.md § Vehicle scope per source](09-glossary.md#vehicle-scope-per-source) for the cross-country table.
+
 **Why two PDFs:** ANAC splits the headline market total (Mercado Automotor) from the alternative-drivetrain breakdown (Cero y Bajas Emisiones). Both are needed to fill one CSV row; partial writes would produce wrong charts because BEV/PHEV/HEV would default to 0 and inflate ICE.
 
 **Why MHEV → ICE:** ANAC reports mild-hybrids (Microhíbridos) as a separate line that didn't exist historically and isn't in `data/Chile.csv`'s schema. Per maintainer's call we bucket them into ICE via the implicit subtraction (`ICE = TOTAL − BEV − PHEV − HEV − OTHERS`) rather than introducing a new column.

--- a/docs/architecture/09-glossary.md
+++ b/docs/architecture/09-glossary.md
@@ -4,19 +4,37 @@ Domain jargon used across the codebase, the data, and the chats. Look here when 
 
 ## Vehicle / fuel categories
 
-| Term | Meaning | Notes |
+These are the *technical* definitions — what physically distinguishes one drivetrain from another. How each one is mapped into the CSV schema and the chart rollups is in the rightmost column.
+
+| Term | Definition | In our schema |
 |---|---|---|
-| **BEV** | Battery Electric Vehicle | Pure-electric, no combustion engine. The headline metric. |
-| **PHEV** | Plug-in Hybrid Electric Vehicle | Has both a battery (chargeable from outside) and a combustion engine. |
-| **EREV** | Extended-Range Electric Vehicle | A specific PHEV variant where the engine only acts as a generator for the battery. Some sources (notably China's CPCA from 2025-01-01 onwards) report this separately from PHEV. In our 3-curve plot, EREV is folded into PHEV. In the TTM stack, EREV is its own layer. |
-| **HEV** | (Full) Hybrid Electric Vehicle | Battery is regen-charged only, can't be plugged in. Counts as ICE in our 3-curve rollup; renders as a parenthetical "of which Xp were HEV" in the post text. |
-| **MHEV** | Mild Hybrid | Small battery assist; effectively ICE. Reserved column, not yet used. |
-| **PETROL / DIESEL / FLEXFUEL / ETHANOL** | Conventional ICE subcategories | Where reported. |
-| **GAS / CNG / LPG** | Gas-powered ICE variants | Reserved columns; only Georgia currently uses GAS (via a re-mapped PETROL-GAS column). |
-| **OTHERS** | Catch-all | Any fuel not fitting the named categories. |
-| **ICE** | Internal Combustion Engine, single bucket | Used by countries (China, USA, South Korea, Thailand, Chile) that don't break ICE down further. In the 3-curve rollup ICE is *derived* (TOTAL − BEV − PHEV − EREV); when reported as an explicit column it's used directly in the TTM stack. |
-| **TOTAL** | All registrations in the period | Required field. The denominator for every share computation. |
-| **Hybrid (capital, no qualifier)** | A country's single combined hybrid bucket | Some sources (Türkiye `HYBRIDS`, Georgia `Hybrid`) don't split PHEV vs HEV. In our schema this maps to the `HEV` column and the post text labels it as "Hybrid" without parentheses. |
+| **BEV** | Battery Electric Vehicle. Propelled exclusively by one or more electric motors drawing from an on-board traction battery, which is recharged from the grid. No combustion engine on board. | `BEV` column. Required for every country. Headline metric of the project. |
+| **PHEV** | Plug-in Hybrid Electric Vehicle. Combines a combustion engine with a traction battery that can be recharged from the grid. Can operate in pure-electric mode while the battery has charge; the engine engages above a state-of-charge or speed threshold. Always has an external charging port. | `PHEV` column. Counted as PHEV in the 3-curve rollup; in the TTM stack EREVs (where reported) appear as a separate layer above PHEV. |
+| **EREV / P-EREV** | Extended-Range Electric Vehicle. A PHEV variant where the combustion engine is mechanically decoupled from the wheels and acts only as a generator that recharges the battery. P-EREV adds an external charging port (otherwise the engine is the sole energy source). Some sources (China CPCA from 2025-01, ANAC from 2025) lump EREV/P-EREV into PHEV; we follow each source's reporting. | `EREV` column when the source breaks it out (currently China only). Folded into PHEV in the 3-curve plot; its own layer in `_ttm_shares`. |
+| **HEV** | (Full) Hybrid Electric Vehicle, a.k.a. self-charging hybrid. Combustion engine plus traction battery, but the battery is recharged *only* by regenerative braking and the engine itself — there is no external charging port. Can drive short distances on electric power alone. | `HEV` column. Counted as ICE in the 3-curve rollup; renders as a parenthetical "of which Xp were HEV" in the post text. |
+| **MHEV** | Mild Hybrid (Microhíbrido / Mild-Hybrid). Combustion engine with a small 48V (or smaller) battery that assists with start-stop, regenerative recovery, and brief torque-fill. The MHEV system *cannot* propel the vehicle on electric power alone. Mechanically closer to a conventional ICE than to a full HEV. | `MHEV` column (reserved; not yet populated in any active CSV). Where a source reports MHEV without giving us a column to put it in (e.g. Chile), it falls into the ICE bucket via the implicit `ICE = TOTAL − BEV − PHEV − HEV − OTHERS` subtraction. |
+| **ICE** | Internal Combustion Engine. Catch-all for any drivetrain whose sole propulsion source is fuel combustion: petrol, diesel, ethanol, flex-fuel, CNG, LPG, hydrogen ICE, etc. Includes MHEVs by maintainer convention (the mild-hybrid systems don't change the propulsion principle). | `ICE` column when the source reports a single ICE total without splitting fuels (China, USA, South Korea, Thailand, Chile). Otherwise *derived* in the 3-curve plot as `TOTAL − BEV − PHEV − EREV` and shown in the TTM stack as the sum of `PETROL` + `DIESEL` + `FLEXFUEL` + `OTHERS` (+ explicit `ICE` column if present). |
+| **PETROL / DIESEL** | Pure-petrol / pure-diesel ICE. Conventional spark-ignition or compression-ignition engine with no hybrid assist. | `PETROL` / `DIESEL` columns. *Caveat:* a small number of source statistics fold petrol-HEV variants into `PETROL` rather than `HEV` (and the same for diesel). Headline ICE/BEV/PHEV trajectories are unaffected — both end up in ICE — but per-fuel TTM shares can be off. Improving the upstream split is a known data-quality task. |
+| **FLEXFUEL** | Engine certified to run on a variable mix of petrol and ethanol (E20–E100). Brazil-specific in practice (>80% of new sales there); a small number of Sweden rows also use this column. Counted as ICE in every output. | `FLEXFUEL` column. |
+| **ETHANOL** | Pure ethanol (E85+) ICE. Reserved; in practice folded into `OTHERS` or `FLEXFUEL` upstream. Counted as ICE. | `ETHANOL` column (reserved). |
+| **GAS / CNG / LPG** | Gas-powered ICE: generic natural gas (`GAS`), compressed natural gas (`CNG`), liquefied petroleum gas (`LPG`). | Reserved columns. Only Georgia currently uses `GAS` (via the re-mapped `PETROL-GAS` source column). Counted as ICE. |
+| **OTHERS** | Catch-all for anything the source doesn't put in a named bucket. Typically absorbs `GAS`/`CNG`/`LPG`/`ETHANOL` and hydrogen fuel-cell (FCEV) where they appear. | `OTHERS` column. Counted as ICE in every output chart. |
+| **FCEV** | Fuel-Cell Electric Vehicle. Electric motor powered by a hydrogen fuel cell. We do not yet have a dedicated column — sources that report FCEV either fold it into `BEV` (rare, technically wrong but consistent with their definition) or into `OTHERS`. | No dedicated column today. |
+| **TOTAL** | All registrations in the period, summed across every drivetrain. | `TOTAL` column. Required. The denominator for every share computation. |
+| **Hybrid (capital, no qualifier)** | A source's single combined hybrid bucket — sources that don't split PHEV vs HEV (Türkiye `HYBRIDS`, Georgia `Hybrid`). | Mapped to the `HEV` column on ingest; the post text labels it as "Hybrid" without parentheses to flag the ambiguity. |
+
+## Vehicle scope per source
+
+The technical definitions above are universal; what varies between countries is **which vehicles the source counts in the first place**. Most countries' headline reports cover only light-duty passenger and commercial vehicles, but the exact weight cut-off depends on national regulation. This is the table to keep up-to-date as new countries are added.
+
+| Country | Source | Vehicle scope (included) | Excluded | Authority |
+|---|---|---|---|---|
+| Chile | ANAC | "Livianos y medianos": passenger cars (Vehículo de Pasajeros), SUVs, pickups (Camionetas) and light commercial vehicles (Vehículo Comercial). **Livianos** = peso bruto vehicular (GVWR) < 2.700 kg; **Medianos** = 2.700 ≤ GVWR < 3.860 kg. | Camiones (trucks ≥ 3.860 kg GVWR), Buses (all). ANAC publishes those in the same monthly PDFs but we don't ingest them. | DS N°241/2014, MTT (Reglamento del Impuesto Adicional a vehículos motorizados nuevos, livianos y medianos) |
+| Brazil | ANFAVEA | "Automóveis e Comerciais Leves": passenger cars + light commercial vehicles. ANFAVEA's sheet III is split into two blocks — the first is what we parse. | Caminhões e Ônibus (trucks + buses): different fuel taxonomy, excluded by stopping the parser at the "Fonte:" end-of-table marker. | ANFAVEA classification (industry self-definition); no single legal decree referenced. |
+| Others | various | *To be documented per country as the scope is confirmed by the maintainer or pulled from the agency's methodology page.* | — | — |
+
+**Why this matters:** the headline BEV-share number for a country is `BEV_count / TOTAL_count`, and `TOTAL` is exactly the count of vehicles within that source's scope. Different scopes are not directly comparable — Chile counting up to 3.860 t is broader than EU `M1+N1` (≤ 3.5 t) but narrower than US light-duty (≤ 8.500 lb ≈ 3.856 t). Document scope before comparing absolute volumes across countries.
+
 
 ## Time / period
 

--- a/scripts/fetch_chile.py
+++ b/scripts/fetch_chile.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""
+Fetch Chile vehicle registration data from ANAC and update data/Chile.csv.
+
+Usage
+-----
+    python scripts/fetch_chile.py [--year YEAR] [--month MONTH] \
+        [--mercado-url URL] [--emisiones-url URL] [--csv PATH] [--force]
+
+* --year / --month  Override the target month (default: previous calendar month).
+* --mercado-url     Direct URL/path to the Mercado Automotor PDF.
+* --emisiones-url   Direct URL/path to the Cero y Bajas Emisiones PDF.
+* --csv             Target CSV (default: data/Chile.csv).
+* --force           Re-process even if the target period already exists.
+
+Invoked by .github/workflows/fetch-chile.yml on a daily cron from the 14th of
+each month onward, plus manual workflow_dispatch. When the CSV changes, the
+workflow commits data/Chile.csv and triggers render-country.yml for Chile.
+
+Data source
+-----------
+ANAC (Asociación Nacional Automotriz de Chile) publishes two monthly PDFs at
+https://www.anac.cl/category/estudio-de-mercado/ :
+
+  1. "Informe Mercado Automotor"            → provides TOTAL (livianos y medianos)
+  2. "Informe Cero y Bajas Emisiones"       → provides BEV, PHEV, HEV
+
+Both PDFs for a given month are usually published a few weeks into the
+following month, but NOT necessarily at the same time. We only write a CSV
+row when both are available for the target month (no partial writes).
+
+Parsing strategy
+----------------
+* Mercado Automotor: locate the first standalone "Total Mes" label in the
+  text; the headline integer on the line immediately above is the monthly
+  total for livianos y medianos. ANAC's narrative phrasing varies between
+  reports, so the bar-chart label is more stable.
+
+* Cero y Bajas Emisiones: the report contains a summary table
+
+      Tipo Vehículo              Acum <Month> YEAR    Var% Acum    <Month>    Var% Mes
+      Eléctricos                 1.802                61,3 %       1.008      168,8%
+      Híbrido Enchufables        1.610                318,2 %      766        410,7%
+      Híbrido Convencional       3.665                97,1 %       1.812      164,5%
+      Microhíbridos              4.833                74,1 %       2.307      97,9%
+
+  For each labelled row we extract the 3rd column (monthly value):
+      Eléctricos          → BEV
+      Híbrido Enchufables → PHEV
+      Híbrido Convencional → HEV
+  Microhíbridos (MHEV) is NOT broken out — it falls into the ICE bucket via
+  the implicit subtraction TOTAL − BEV − PHEV − HEV − OTHERS.
+
+CSV layout
+----------
+Existing data/Chile.csv columns:
+    period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,ICE,TOTAL,notes
+
+For new rows we set:
+    BEV, PHEV, HEV  ← from emisiones PDF
+    PETROL, DIESEL, OTHERS  ← 0
+    TOTAL  ← from mercado PDF
+    ICE    ← TOTAL − BEV − PHEV − HEV − OTHERS (captures gasoline+diesel+MHEV)
+    notes  ← "<mercado_url> | <emisiones_url>"
+
+Per the user's rule we only ever write the most recent month; older rows are
+never touched, even if a later report would adjust them.
+
+HTTP details
+------------
+ANAC's WordPress hardens against basic User-Agents — we identify as a regular
+desktop browser via HTTP_HEADERS to avoid 403s.
+"""
+import argparse
+import csv
+import io
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+import requests
+from bs4 import BeautifulSoup
+from pypdf import PdfReader
+
+ANAC_PAGE = "https://www.anac.cl/category/estudio-de-mercado/"
+
+HTTP_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "es-CL,es;q=0.9,en;q=0.8",
+}
+
+CSV_COLUMNS = [
+    "period", "time_interval", "variant", "source",
+    "BEV", "PHEV", "HEV", "PETROL", "DIESEL", "OTHERS",
+    "ICE", "TOTAL", "notes",
+]
+
+SPANISH_MONTHS = {
+    1: "Enero", 2: "Febrero", 3: "Marzo", 4: "Abril",
+    5: "Mayo", 6: "Junio", 7: "Julio", 8: "Agosto",
+    9: "Septiembre", 10: "Octubre", 11: "Noviembre", 12: "Diciembre",
+}
+
+# Labels in the emisiones summary table → CSV column
+EMISIONES_LABELS = {
+    "Eléctricos": "BEV",
+    "Híbrido Enchufables": "PHEV",
+    "Híbrido Convencional": "HEV",
+}
+
+# Row pattern after stripping the label: <int> <pct>% <int> <pct>%
+# Captures (acumulado, monthly). Integers may carry "1.234" thousand separators;
+# percentages use comma decimals ("61,3 %") and we tolerate "0 %" with no decimal.
+_EMISIONES_ROW = re.compile(
+    r"^(\d{1,3}(?:\.\d{3})*)\s+"
+    r"-?\d+(?:[,.]\d+)?\s*%\s+"
+    r"(\d{1,3}(?:\.\d{3})*)\s+"
+    r"-?\d+(?:[,.]\d+)?\s*%"
+)
+
+
+def previous_month(today: date) -> tuple[int, int]:
+    """Returns (year, month) of the calendar month before `today`."""
+    if today.month == 1:
+        return today.year - 1, 12
+    return today.year, today.month - 1
+
+
+def latest_period(csv_path: str) -> str | None:
+    if not Path(csv_path).exists():
+        return None
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        periods = [row["period"] for row in csv.DictReader(f)]
+    return max(periods) if periods else None
+
+
+def discover_pdfs(year: int, month: int) -> tuple[str | None, str | None]:
+    """Returns (mercado_url, emisiones_url) for the given year/month, or None each."""
+    month_name = SPANISH_MONTHS[month]
+    print(f"Scanning {ANAC_PAGE} for {month_name} {year} PDFs …")
+    resp = requests.get(ANAC_PAGE, headers=HTTP_HEADERS, timeout=30)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    # Filenames seen in the wild:
+    #   04-ANAC-Mercado-Automotor-Abril-2026.pdf            (canonical)
+    #   04-ANAC-Mercado-Automotor-Abril-202634.pdf          (with version suffix)
+    #   03-ANAC-Informe-Cero-y-Bajas-Emisiones-Marzo-2026.pdf
+    #   02-ANAC-Informe-Cero-y-Bajas-Emisiones-Febrero-202677.pdf
+    # The leading "NN-" is the month number; trailing "<digits>" after the
+    # year is a versioning quirk.
+    mercado_re = re.compile(
+        rf"ANAC-Mercado-Automotor-{month_name}-{year}\d*\.pdf",
+        re.IGNORECASE,
+    )
+    emisiones_re = re.compile(
+        rf"ANAC-Informe-Cero-y-Bajas-Emisiones-{month_name}-{year}\d*\.pdf",
+        re.IGNORECASE,
+    )
+
+    mercado_url = emisiones_url = None
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if mercado_url is None and mercado_re.search(href):
+            mercado_url = href if href.startswith("http") else "https://www.anac.cl" + href
+        if emisiones_url is None and emisiones_re.search(href):
+            emisiones_url = href if href.startswith("http") else "https://www.anac.cl" + href
+
+    return mercado_url, emisiones_url
+
+
+def load_pdf_bytes(url_or_path: str) -> bytes:
+    if url_or_path.startswith("http://") or url_or_path.startswith("https://"):
+        print(f"Downloading: {url_or_path}")
+        resp = requests.get(url_or_path, headers=HTTP_HEADERS, timeout=60)
+        resp.raise_for_status()
+        return resp.content
+    path = url_or_path.replace("file://", "")
+    with open(path, "rb") as f:
+        return f.read()
+
+
+def pdf_text(pdf_bytes: bytes) -> str:
+    """Concatenate text of every PDF page in order.
+
+    pypdf's reading-order extraction collapses multi-column chart layouts —
+    the bar-chart headline numbers come out glued to their labels
+    (e.g. "27.572Total Mes"), which the parsers below match explicitly.
+    """
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    return "\n".join((page.extract_text() or "") for page in reader.pages)
+
+
+# Headline bar-chart value: "27.572Total Mes" or "27.572 Total Mes".
+# ANAC reports always present livianos y medianos before camiones and buses,
+# so the FIRST occurrence in reading order is the figure we want.
+_TOTAL_MES_RE = re.compile(r"(\d{1,3}(?:\.\d{3})+)\s*Total\s*Mes")
+
+
+def parse_mercado_total(text: str) -> int:
+    """Extract monthly TOTAL (livianos y medianos) from Mercado Automotor PDF."""
+    m = _TOTAL_MES_RE.search(text)
+    if not m:
+        raise RuntimeError(
+            "Could not locate 'Total Mes' headline in Mercado Automotor PDF"
+        )
+    return int(m.group(1).replace(".", ""))
+
+
+def parse_emisiones(text: str) -> dict[str, int]:
+    """Extract BEV/PHEV/HEV monthly counts from Cero y Bajas Emisiones PDF.
+
+    Looks for lines that begin (after whitespace strip) with one of the
+    fuel-type labels, then extracts the 2nd integer (= monthly column)
+    from the trailing `<int> <pct>% <int> <pct>%` pattern.
+    """
+    result: dict[str, int] = {}
+    for line in text.split("\n"):
+        stripped = line.strip()
+        for label, csv_key in EMISIONES_LABELS.items():
+            if csv_key in result:
+                continue
+            if stripped.startswith(label):
+                rest = stripped[len(label):].strip()
+                m = _EMISIONES_ROW.match(rest)
+                if m:
+                    result[csv_key] = int(m.group(2).replace(".", ""))
+                    break
+
+    missing = set(EMISIONES_LABELS.values()) - set(result.keys())
+    if missing:
+        raise RuntimeError(
+            f"Could not extract {sorted(missing)} from Cero y Bajas Emisiones PDF"
+        )
+    return result
+
+
+def upsert_row(csv_path: str, period: str, row: dict, force: bool) -> bool:
+    """Append `row` for `period` to the CSV (sorted). Returns True if written.
+
+    Returns False without writing if the period already exists and not --force.
+    """
+    existing: dict[str, dict] = {}
+    if Path(csv_path).exists():
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            for r in csv.DictReader(f):
+                existing[r["period"]] = r
+
+    if period in existing and not force:
+        print(f"  Period {period} already in CSV — not overwriting (use --force).")
+        return False
+
+    existing[period] = row
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS, lineterminator="\n")
+        writer.writeheader()
+        for p in sorted(existing.keys()):
+            writer.writerow(existing[p])
+    return True
+
+
+def build_row(period: str, total: int, fuels: dict[str, int],
+              mercado_url: str, emisiones_url: str) -> dict:
+    bev = float(fuels["BEV"])
+    phev = float(fuels["PHEV"])
+    hev = float(fuels["HEV"])
+    ice = float(total) - bev - phev - hev
+    return {
+        "period": period,
+        "time_interval": "monthly",
+        "variant": "Whole",
+        "source": "ANAC",
+        "BEV": bev,
+        "PHEV": phev,
+        "HEV": hev,
+        "PETROL": 0.0,
+        "DIESEL": 0.0,
+        "OTHERS": 0.0,
+        "ICE": ice,
+        "TOTAL": float(total),
+        "notes": f"{mercado_url} | {emisiones_url}",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--year", type=int)
+    parser.add_argument("--month", type=int, choices=range(1, 13))
+    parser.add_argument("--mercado-url", help="Direct URL/path to Mercado Automotor PDF")
+    parser.add_argument("--emisiones-url", help="Direct URL/path to Cero y Bajas Emisiones PDF")
+    parser.add_argument("--csv", default="data/Chile.csv")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-process even if target period already exists")
+    args = parser.parse_args()
+
+    # Determine target month (defaults to the calendar month before today)
+    if args.year and args.month:
+        target_year, target_month = args.year, args.month
+    elif args.year or args.month:
+        sys.exit("--year and --month must be given together")
+    else:
+        target_year, target_month = previous_month(date.today())
+    target_period = f"{target_year}-{target_month:02d}"
+    print(f"Target period: {target_period} ({SPANISH_MONTHS[target_month]} {target_year})")
+
+    # Short-circuit: if already in CSV and not forced, no-op.
+    if not args.force:
+        latest = latest_period(args.csv)
+        if latest and latest >= target_period:
+            print(f"Latest period in CSV is {latest} ≥ {target_period} — nothing to do.")
+            return 0
+
+    # Resolve PDF URLs
+    if args.mercado_url and args.emisiones_url:
+        mercado_url = args.mercado_url
+        emisiones_url = args.emisiones_url
+    elif args.mercado_url or args.emisiones_url:
+        sys.exit("--mercado-url and --emisiones-url must be given together "
+                 "(or both omitted to auto-discover)")
+    else:
+        mercado_url, emisiones_url = discover_pdfs(target_year, target_month)
+        if not mercado_url or not emisiones_url:
+            missing = []
+            if not mercado_url: missing.append("Mercado Automotor")
+            if not emisiones_url: missing.append("Cero y Bajas Emisiones")
+            print(f"PDFs not yet published for {target_period}: missing {missing}. "
+                  "Will retry on next scheduled run.")
+            return 0
+        print(f"Found Mercado:    {mercado_url}")
+        print(f"Found Emisiones:  {emisiones_url}")
+
+    # Parse
+    mercado_text = pdf_text(load_pdf_bytes(mercado_url))
+    total = parse_mercado_total(mercado_text)
+    print(f"Parsed TOTAL: {total}")
+
+    emisiones_text = pdf_text(load_pdf_bytes(emisiones_url))
+    fuels = parse_emisiones(emisiones_text)
+    print(f"Parsed fuels: BEV={fuels['BEV']}, PHEV={fuels['PHEV']}, HEV={fuels['HEV']}")
+
+    # Sanity: ICE must be non-negative
+    ice = total - fuels["BEV"] - fuels["PHEV"] - fuels["HEV"]
+    if ice < 0:
+        sys.exit(f"Computed ICE is negative ({ice}); parser likely picked wrong values. "
+                 f"TOTAL={total}, fuels={fuels}")
+    print(f"Computed ICE:  {ice}")
+
+    row = build_row(target_period, total, fuels, mercado_url, emisiones_url)
+    if upsert_row(args.csv, target_period, row, args.force):
+        print(f"\nWrote {target_period} to {args.csv}")
+    else:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fetch_chile.py
+++ b/scripts/fetch_chile.py
@@ -29,6 +29,14 @@ Both PDFs for a given month are usually published a few weeks into the
 following month, but NOT necessarily at the same time. We only write a CSV
 row when both are available for the target month (no partial writes).
 
+Vehicle scope
+-------------
+"Livianos y medianos" = passenger cars + SUVs + pickups + light commercial
+vehicles up to 3.860 kg GVWR (livianos < 2.700 kg, medianos 2.700–3.859 kg)
+per DS N°241/2014 del MTT. Trucks (camiones) and buses appear in the same
+PDFs in separate sections; we explicitly do NOT ingest them. See
+docs/architecture/09-glossary.md § Vehicle scope per source.
+
 Parsing strategy
 ----------------
 * Mercado Automotor: locate the first standalone "Total Mes" label in the


### PR DESCRIPTION
Adds scripts/fetch_chile.py + fetch-chile.yml workflow, mirroring the
Brazil pattern. ANAC publishes two PDFs per month (Mercado Automotor
for the TOTAL, Cero y Bajas Emisiones for BEV/PHEV/HEV) at different
times, so the cron runs daily from the 14th and the script self-
throttles via the CSV's latest period — most runs are a no-op until
both PDFs are out.

Parses TOTAL from the bar-chart "Total Mes" headline and BEV/PHEV/HEV
from the summary table's monthly column. MHEV is bucketed into ICE
via the implicit subtraction TOTAL − BEV − PHEV − HEV − OTHERS. Only
the newest month is ever written; historical rows are not touched.

Verified against five sample ANAC PDFs (Dec 2025, Feb 2026, Mar 2026,
Apr 2026) — all parse to values matching data/Chile.csv.