### PR TITLE
fix(indonesia): defend params.csv against external v1=0 round-trip corruption

### DIFF
--- a/R/render_country.R
+++ b/R/render_country.R
@@ -134,6 +134,13 @@ weight <- compute_weight(df)
 cat(sprintf("[upsert] weights.csv %s/%s  weight=%s\n", country, variant, format(weight, big.mark = ",")))
 upsert_weights("weights.csv", country, variant, weight, data_per)
 
+# Self-heal any rows whose v1 was rounded to 0 by an external tool — see
+# heal_v1_zero_rows() in R/upsert.R for full context. Runs on every render so
+# Indonesia-style corruption from the legacy "auto-publish model" script is
+# repaired the next time CI touches params.csv, even if a different country
+# is being rendered.
+heal_v1_zero_rows("params.csv", "weights.csv")
+
 # Build the social-media post text and write to posts/<slug>.txt (latest, what
 # the Gallery's Copy-post button + the Apple Shortcut fetch) plus a periodised
 # copy posts/<slug>_<period>.txt that stays around as a history record.

--- a/R/upsert.R
+++ b/R/upsert.R
@@ -79,6 +79,70 @@ upsert_params <- function(path, country, variant, fit, data_per, source_str) {
   writeLines(lines, path, useBytes = TRUE)
 }
 
+# params.csv self-heal for "Indonesia v1=0" corruption.
+# Background: the maintainer's legacy local "auto-publish model" scripts read
+# params.csv with R defaults, which round tiny v1 values (≤ ~1e-7) to literal
+# zero on write-back. For fast-adoption markets the fit produces v1 ≈ -6e-20
+# with v2 > 10; once stored as 0 in the CSV, the page's Durations table
+# anchors the Weibull ~20 years too far in the future and reports a ~5-year
+# 20→80 transition instead of the true ~2 years.
+# Strategy: on every render, scan params.csv for rows that match the
+# corruption fingerprint (|v1| < 1e-25 AND v2 ≥ v2_threshold) and that have
+# a backing data/<Country>.csv. Re-fit those rows in-place. Cheap when no
+# corruption is present (one file read + numeric parse).
+# Full background: docs/architecture/08-deploy-ops.md § "Indonesia v1=0 corruption".
+heal_v1_zero_rows <- function(params_path = "params.csv",
+                              weights_path = "weights.csv",
+                              v2_threshold = 10) {
+  if (!file.exists(params_path)) return(invisible())
+  lines <- readLines(params_path, encoding = "UTF-8", warn = FALSE)
+  if (length(lines) < 2) return(invisible())
+  header <- strsplit(lines[1], ",", fixed = TRUE)[[1]]
+  ci <- function(name) match(name, header)
+  ci_country <- ci("country"); ci_variant <- ci("variant")
+  ci_v1 <- ci("v1"); ci_v2 <- ci("v2")
+  if (any(is.na(c(ci_country, ci_variant, ci_v1, ci_v2)))) return(invisible())
+
+  i <- 2L
+  while (i <= length(lines)) {
+    parts <- strsplit(lines[i], ",", fixed = TRUE)[[1]]
+    need_max <- max(ci_country, ci_variant, ci_v1, ci_v2)
+    if (length(parts) >= need_max) {
+      v1 <- suppressWarnings(as.numeric(parts[ci_v1]))
+      v2 <- suppressWarnings(as.numeric(parts[ci_v2]))
+      if (!is.na(v1) && !is.na(v2) && abs(v1) < 1e-25 && v2 >= v2_threshold) {
+        country <- parts[ci_country]; variant <- parts[ci_variant]
+        csv_path <- file.path("data", paste0(country, ".csv"))
+        if (file.exists(csv_path)) {
+          cat(sprintf("[heal] %s/%s: v1=0 corruption (v2=%.3f) — re-fitting from %s\n",
+                      country, variant, v2, csv_path))
+          df_all <- load_country_csv(csv_path)
+          df <- df_all[df_all$variant == variant, ]
+          if (nrow(df) > 0) {
+            fit <- fit_history(df)
+            data_per <- data_per_from_df(df)
+            source_str <- df$source[!is.na(df$source) & nzchar(df$source)][1]
+            if (is.na(source_str)) source_str <- ""
+            upsert_params(params_path, country, variant, fit, data_per, source_str)
+            weight <- compute_weight(df)
+            upsert_weights(weights_path, country, variant, weight, data_per)
+            cat(sprintf("[heal] %s/%s: restored v1=%.4e v2=%.4f\n",
+                        country, variant, fit$v1, fit$v2))
+            # File rewritten — reload and rescan from the top
+            lines <- readLines(params_path, encoding = "UTF-8", warn = FALSE)
+            i <- 1L
+          }
+        } else {
+          cat(sprintf("[heal] %s/%s: v1=0 detected but %s missing — skipping\n",
+                      country, variant, csv_path))
+        }
+      }
+    }
+    i <- i + 1L
+  }
+  invisible()
+}
+
 upsert_weights <- function(path, country, variant, weight, data_per) {
   header <- "country,variant,weight,data_per,model_date"
   weight_str <- if (is.finite(weight)) format(round(weight), scientific = FALSE, trim = TRUE) else ""

--- a/docs/architecture/03-data-objects.md
+++ b/docs/architecture/03-data-objects.md
@@ -136,6 +136,17 @@ Germany,Whole,-1.050261627753e-4,2.898020288277,2011,2026-04,2026-05-08,KBA,,-3.
 
 This matches what the maintainer's local R script produces, so PR diffs from local-R pushes and from the Render Action look the same.
 
+### Known fragility — Indonesia-style `v1=0` corruption
+
+Fast-adoption markets (currently only Indonesia) fit to `v1 ≈ -6e-20` with `v2 > 10`. R's default `format()` / `round(x, 6)` rounds these to literal `0`, so any external tool that round-trips `params.csv` via base-R defaults silently destroys the precision. Once `v1 = 0` is in the CSV, the page used to anchor the Weibull ~20 years too far into the future and reported a ~5-year 20→80 transition for Indonesia (the truth is ~2.3 years).
+
+The schema is deliberately **not** extended to defend against this — every defence sits in code, so external tools that aren't aware of the new schema can't accidentally undo it:
+
+- **Frontend `index.html::recoverV1FromAnchor()`** — at load time, every `v1 = 0` row is rewritten by anchoring the Weibull at a v2-dependent BEV share at `data_per` (28 % for `v2 ≥ 10` like Indonesia, else 50 %). Calibrated against the live Indonesia fit, the resulting 20→80 lands within ~1 day of the true fit.
+- **Backend `R/upsert.R::heal_v1_zero_rows()`** — invoked from `R/render_country.R` at the end of every render. Scans `params.csv` for rows with `|v1| < 1e-25` AND `v2 ≥ 10`, re-fits them from `data/<Country>.csv`, and rewrites the row in place. Cheap when nothing is corrupted (file read + numeric parse).
+
+See [08-deploy-ops.md § "Indonesia v1=0 corruption"](08-deploy-ops.md#indonesia-v10-corruption) for the operator-facing runbook and the long-form root-cause story.
+
 ---
 
 ## 3.3 Aggregate Weights

--- a/docs/architecture/08-deploy-ops.md
+++ b/docs/architecture/08-deploy-ops.md
@@ -14,6 +14,7 @@ Operational runbook. How to deploy, how to trigger, how to debug. Commands you c
 | Hide spam feedback | Add `hidden` label to the issue | [§ 8.6](#86-moderate-feedback) |
 | Bulk-render all countries | Loop through countries calling [§ 8.2](#82-trigger-a-country-render) one at a time | [§ 8.7](#87-bulk-rerender) |
 | Debug Worker errors | Cloudflare dashboard → Workers → Tail logs | [§ 8.8](#88-debugging) |
+| Indonesia table shows ~5y 20→80 again | Frontend + backend recovery both already in place — see § "Indonesia v1=0 corruption" | [§ 8.8](#indonesia-v10-corruption) |
 
 ## 8.1 Deploy the Worker
 
@@ -175,6 +176,50 @@ CI is slower (~30–120 s × 43 countries) but produces deterministic byte-outpu
    - **`no rows for variant 'X' in data/<Country>.csv`** → variant not present in the CSV. Either submit data for it or change the variant input.
    - **`Failed to install package 'showtext'` or similar** → CI cache miss + apt prebuild missing. Re-run; usually transient.
    - **`Error in optim(...)`** → degenerate input (all-zero column, single data point). Check the CSV for the period range.
+
+### Indonesia v1=0 corruption
+
+#### Symptom
+
+The Durations table on the page shows Indonesia's 20→80 transition as ~5 years (sometimes also Custom-pct or "Numerical speed" looking nonsensical) although a fresh R render via § 8.2 produces a 20→80 of ~2 years. Re-running § 8.2 for Indonesia "fixes" it for a while, then the bad values come back after some unrelated country has been rendered.
+
+#### Root cause
+
+1. The R fit (`R/fit.R::fit_history`) is mathematically stable for Indonesia. With current data it converges to `v1 = -6.114813777364e-20, v2 = 15.1628, t0 = 2009`. The 20→80 derived from these is ~2.25 years — correct.
+2. `R/upsert.R::upsert_params` writes `v1` to `params.csv` in scientific notation (`-6.114813777364e-20`). Standard R `read.csv` / `write.csv` round-trips this losslessly.
+3. The maintainer's **legacy local "auto-publish model" R script** (off-repo, runs from RStudio on the Mac, generates commits like `China: auto-publish model`) reads `params.csv` with code closer to `round(scale, 6)` / default `format()`. Both of those collapse anything below ~1e-7 to literal `0`. The script then writes the whole CSV back, so Indonesia's row goes from `…,-6.114813777364e-20,…` to `…,0,…` (sometimes `-0`).
+4. The page used to patch `v1 = 0 → -1e-24` inside `inv_x_years` so the math wouldn't divide by zero. With Indonesia's `v2 ≈ 15`, that constant pushes the entire Weibull ~20 years into the future: 20 % is reached around 2042, 80 % around 2047 → reported 20→80 ≈ 4.9 years. Other countries fit to smaller `v2` (≤ 7) and weren't visibly affected by the same constant.
+5. Re-running § 8.2 for Indonesia restores the precision, so the value flips back. Until the next time the legacy script touches `params.csv`.
+
+Confirmed in Git history: alternating commits like `chore: render Indonesia (Whole)` → tiny non-zero `v1`, followed by `China: auto-publish model` → `v1=0`, throughout May 2026.
+
+#### Defence in depth
+
+Two layers, both kept on purpose so either alone covers the bug while we keep the legacy script around:
+
+| Layer | File / function | What it does |
+|---|---|---|
+| **Frontend** | `index.html::recoverV1FromAnchor()` + `applyV1Recovery()` | At every CSV load (Thresholds, Durations, Builder, World Map, Fleet) every row with `v1 = 0` is rewritten on the fly. The Weibull is anchored at a v2-dependent BEV share at `data_per`: 28 % for `v2 ≥ 10` (the fast-adopter corruption pattern, calibrated against Indonesia's live fit), 50 % otherwise. The reported 20→80 duration lands within ~1 day of the truth for Indonesia and stays bounded for the hypothetical case of a future v2≥10 country whose data_per sits earlier in its rising flank (~40 days worst case). Page never reports the 4.9-year garbage value again, even if `params.csv` was just clobbered. |
+| **Backend** | `R/upsert.R::heal_v1_zero_rows()`, invoked from `R/render_country.R` | At the end of every CI render (regardless of which country was the trigger), scan `params.csv` for the corruption fingerprint (`abs(v1) < 1e-25` AND `v2 ≥ 10`). For each hit, re-fit from `data/<Country>.csv` and rewrite the row. Cheap when nothing is wrong; fully autonomous when something is. Means the very next CI render after a clobbered commit cleans the file. |
+
+Both layers stay in place on purpose:
+- The **backend self-heal** is the canonical fix — once it runs, params.csv carries the correct tiny-negative `v1` again. Schema unchanged.
+- The **frontend anchor recovery** is the user-facing safety net — it kicks in for the window between a corrupting local push and the next CI render touching the repo. The page never shows the garbage 4.9-year number to a visitor in that window.
+- Why no `bev_at_data_per` column? Considered and dropped: an explicit anchor column would give < 1 day accuracy unconditionally, but it would extend the public schema. External tools that don't know the new column would silently drop it on round-trip, costing accuracy for any row they touch. Keeping the recovery purely code-side means no external tool can accidentally undo it. The 28 %-anchor heuristic plus the backend self-heal already deliver the same user-visible accuracy in steady state.
+
+If you ever need to manually verify the heal works:
+
+```bash
+# Simulate corruption + run heal in isolation:
+sed -i.bak 's|^Indonesia,Whole,-[^,]*,|Indonesia,Whole,0,|' params.csv
+Rscript -e 'source("R/data.R"); source("R/fit.R"); source("R/upsert.R"); heal_v1_zero_rows()'
+grep '^Indonesia' params.csv     # should show -6.114e-20 again
+mv params.csv.bak params.csv     # roll back the simulated corruption
+```
+
+#### When the legacy script eventually retires
+
+Once the off-repo "auto-publish model" workflow is gone, the corruption source disappears. The recovery code can stay — it costs nothing on clean files and protects against any future tool that does the same thing. Removing it would only be safe if `params.csv` were strictly write-only-by-CI, which is a stronger guarantee than the project currently has.
 
 ### Site shows stale data after a render
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -66,6 +66,10 @@ flowchart LR
 
 The project is a **publication pipeline**. Country registration data lives in versioned CSVs in the repo. R turns CSVs into PNG charts and parameter rows. A static page renders those PNGs from a JSON manifest. Updates flow either from the maintainer's local R run (legacy, fast iteration) or from public submissions that go through a Cloudflare Worker → PR → review → merge → GitHub Action re-render. Every persistent artefact is a file in Git; the only non-Git state is rate-limit counters in Cloudflare KV.
 
+## Known gotchas worth knowing about
+
+- **Indonesia `v1=0` corruption** in `params.csv` — fast-adoption fits round to zero on CSV round-trip by external tools. Defence is layered (frontend `applyV1Recovery`, backend `heal_v1_zero_rows`). Long-form runbook: [08-deploy-ops.md § "Indonesia v1=0 corruption"](08-deploy-ops.md#indonesia-v10-corruption). Schema note: [03-data-objects.md § 3.2](03-data-objects.md#known-fragility--indonesia-style-v10-corruption).
+
 ## When to update these docs
 
 Update the matching chapter in the same PR if your change introduces or modifies:

--- a/index.html
+++ b/index.html
@@ -1095,8 +1095,9 @@ h2 .fb-ctx-btn{width:30px;height:30px;font-size:16px;opacity:.6}
         This view shows the projected time to progress from one market share threshold to another. 
         Columns include 20→80%, 10→90%, a user‑defined X→Y%, and the model’s numerical speed at the inflection point (slope of the tangent). Values are computed client‑side from 
         <code>params.csv</code>. Durations longer than 200 years are shown as “no transition”. <br>
-        Indonesia’s fitted parameters round to almost zero, so a minimum value is enforced —
-        its entries in the table may therefore be slightly off.
+        Indonesia’s fitted parameters round to almost zero in CSV precision, so the table
+        reconstructs them on the fly by anchoring the model to the most recent observation —
+        its entries can therefore be off by a few months in either direction.
       </p>
     </div>
     <div class="container tablepad">
@@ -2273,10 +2274,73 @@ function yearsIndexToDate(xYears, baseline_date, baseline_year){
   const end=new Date(Date.UTC(start.getUTCFullYear()+1,start.getUTCMonth(),start.getUTCDate())); 
   const t=start.getTime()+frac*(end.getTime()-start.getTime()); {const d = new Date(t); return isNaN(d) ? "" : d.toISOString().slice(0,10); } 
 }
+// Anchor-based recovery for v1 values that were rounded to 0 during CSV
+// round-trips by external tools (see docs/architecture/08-deploy-ops.md §
+// "Indonesia v1=0 corruption").
+//
+// We rebuild v1 by anchoring the Weibull to a known BEV share at data_per:
+//   v1 = ln(1 - anchor_share) / (year_at_data_per - (t0 - 1))^v2
+// The anchor share depends on v2 because the corruption-to-zero pattern only
+// happens for fits where v1 was tiny in the first place, and that constrains
+// where data_per sits on the curve:
+//   • v2 < 10  (mature, slow-S markets): data_per is typically near the
+//              inflection, so anchor = 50 % is correct.
+//   • v2 ≥ 10  (fast-adoption markets, e.g. Indonesia v2≈15): the corruption
+//              fingerprint only fires when data_per is in the rising flank
+//              just before inflection, so the fitted share is around 25-30 %.
+//              We anchor at 28 %, which matches Indonesia's fitted share at
+//              its current data_per to ~1 day in the resulting 20→80.
+// Calibrated empirically against the live Indonesia fit (v2=15.16, dt=17.17,
+// truth 20→80 = 2.33 yrs); see the bench in commit history for the sweep.
+// Falls back to -1e-24 (legacy constant) when v2/t0/data_per are missing.
+function recoverV1FromAnchor(v2In, t0In, dataPer){
+  const v2n = normNumber(v2In);
+  const t0n = normNumber(t0In);
+  if(!isFinite(v2n) || v2n <= 0) return -1e-24;
+  if(!isFinite(t0n) || t0n < 1800) return -1e-24;
+  const m = /^(\d{4})-(\d{2})$/.exec(String(dataPer || '').trim());
+  if(!m) return -1e-24;
+  const cal_year = parseInt(m[1], 10);
+  const month    = parseInt(m[2], 10);
+  // Match R/data.R::period_to_year: (y - 1) + (m - 1) / 12
+  const year_model = (cal_year - 1) + (month - 1) / 12;
+  const dt = year_model - (t0n - 1);
+  if(!(dt > 0)) return -1e-24;
+
+  const anchor_share = (v2n >= 10) ? 0.28 : 0.50;
+  const rec = Math.log(1 - anchor_share) / Math.pow(dt, v2n);
+  if(!isFinite(rec) || rec >= 0) return -1e-24;
+  return rec;
+}
+
+// Mutates rows in place. For every row whose v1 (or ice_v1) parses to 0 we
+// substitute the anchor-reconstructed value so all downstream math sees a
+// usable Weibull. The historical -1e-24 patches in inv_x_years /
+// slopeAtInflection / wmBuildRows stay as a defensive last line of defence.
+function applyV1Recovery(rows){
+  if(!Array.isArray(rows)) return rows;
+  for(const r of rows){
+    const v1raw = String(r.v1 ?? '').trim();
+    if(v1raw !== '' && normNumber(v1raw) === 0){
+      r.v1 = String(recoverV1FromAnchor(r.v2, r.t0, r.data_per));
+      r._v1_recovered = true;
+    }
+    const iceRaw = String(r.ice_v1 ?? '').trim();
+    if(iceRaw !== '' && normNumber(iceRaw) === 0){
+      const t0Ice = (r.ice_t0 != null && String(r.ice_t0).trim() !== '') ? r.ice_t0 : r.t0;
+      r.ice_v1 = String(recoverV1FromAnchor(r.ice_v2, t0Ice, r.data_per));
+      r._ice_v1_recovered = true;
+    }
+  }
+  return rows;
+}
+
 function inv_x_years(y,v1,v2,t0){
-  let v1n=normNumber(v1), 
-        v2n=normNumber(v2), 
-        t0n=normNumber(t0); 
+  let v1n=normNumber(v1),
+        v2n=normNumber(v2),
+        t0n=normNumber(t0);
+  // Defensive fallback only — applyV1Recovery() should already have replaced
+  // v1=0 rows at load time. Reached only if a caller bypassed that path.
   if(v1n == 0) v1n = -1e-24;
   if(!(y>0&&y<1))
     return{x:NaN,why:'y∉(0,1)'}; 
@@ -2325,7 +2389,9 @@ function showFatal(msg){
 function renderThresholds(csvText){
   try{
     // D1(b): dedupe defensively before any downstream aggregation.
-    const rows = dedupeParamRows(parseCSV(csvText));
+    // applyV1Recovery rescues Indonesia-style v1=0 corruption — see
+    // docs/architecture/08-deploy-ops.md § "Indonesia v1=0 corruption".
+    const rows = applyV1Recovery(dedupeParamRows(parseCSV(csvText)));
     const mount = document.getElementById('thresholdsMount');
 
     if(!rows.length){
@@ -2612,10 +2678,12 @@ renderTable();
   const CAP_YEARS = 100; // cutoff for "shows no transition"
   // D1(b): every resolve path goes through dedupeParamRows so the
   // Builder, Durations and aggregate callers all receive clean data.
-  function loadParams(){ const urls=['./params.csv','params.csv']; return new Promise((resolve,reject)=>{ (function next(i){ if(i>=urls.length){ if(DEV_SAMPLE){ showSampleDataWarning('params.csv'); resolve(dedupeParamRows(parseCSV(SAMPLE_PARAMS_CSV))); return;} reject(new Error('Could not load params.csv.')); return;} fetch(urls[i],{cache:'no-store'}).then(r=>{if(!r.ok) throw new Error('HTTP '+r.status); return r.text();}).then(txt=>resolve(dedupeParamRows(parseCSV(txt)))).catch(()=>next(i+1)); })(0); }); }
-  function slopeAtInflection(v1,v2){ 
-    let k=normNumber(v2), 
+  function loadParams(){ const urls=['./params.csv','params.csv']; return new Promise((resolve,reject)=>{ (function next(i){ if(i>=urls.length){ if(DEV_SAMPLE){ showSampleDataWarning('params.csv'); resolve(applyV1Recovery(dedupeParamRows(parseCSV(SAMPLE_PARAMS_CSV)))); return;} reject(new Error('Could not load params.csv.')); return;} fetch(urls[i],{cache:'no-store'}).then(r=>{if(!r.ok) throw new Error('HTTP '+r.status); return r.text();}).then(txt=>resolve(applyV1Recovery(dedupeParamRows(parseCSV(txt))))).catch(()=>next(i+1)); })(0); }); }
+  function slopeAtInflection(v1,v2){
+    let k=normNumber(v2),
           v1n=normNumber(v1);
+    // Defensive fallback only — applyV1Recovery() should have replaced v1=0
+    // rows at load time. Reached only if a caller bypassed that path.
     if(v1n == 0)
       v1n = -1e-24;
     if(!(isFinite(k)&&isFinite(v1n))) 
@@ -2711,7 +2779,7 @@ renderTable();
         if(i>=urls.length){ reject(new Error('Could not load params.csv')); return; }
         fetch(urls[i],{cache:'no-store'})
           .then(r=>r.ok?r.text():Promise.reject(new Error('HTTP '+r.status)))
-          .then(t=>resolve(parseCSV(t)))
+          .then(t=>resolve(applyV1Recovery(parseCSV(t))))
           .catch(()=>next(i+1));
       })(0);
     });
@@ -3455,7 +3523,7 @@ async function loadFleetSupportData(){
 
   // D1(b): run the params through the shared dedupe helper before
   // caching, so the Fleet tab's lookups never hit duplicate rows.
-  fleetState.params   = paramsText  ? dedupeParamRows(parseCSV(paramsText))  : [];
+  fleetState.params   = paramsText  ? applyV1Recovery(dedupeParamRows(parseCSV(paramsText)))  : [];
   fleetState.weights  = weightsText ? buildWeightMap(parseCSV(weightsText)) : {};
   fleetState.supportLoaded = true;
 
@@ -4697,7 +4765,9 @@ function wmLoadData(){
           // D1(b): dedupe first so legacy-alias detection also covers
           // the map tab. wmBuildRows still does its own (country, whole,
           // data_per) collapse on top — both are cheap and composable.
-          const rows = dedupeParamRows(parseCSV(txt));
+          // applyV1Recovery rescues Indonesia-style v1=0 corruption — see
+          // docs/architecture/08-deploy-ops.md § "Indonesia v1=0 corruption".
+          const rows = applyV1Recovery(dedupeParamRows(parseCSV(txt)));
           WORLDMAP_STATE.rows = wmBuildRows(rows);
           WORLDMAP_STATE.loaded = true;
           resolve();
@@ -4729,9 +4799,9 @@ function wmBuildRows(csvRows){
   const out = [];
   for (const r of byCountry.values()){
     let v1 = normNumber(r.v1);
-    // v1 exactly 0 means the CSV precision rounded away a tiny negative
-    // value (e.g. Indonesia). Patch to -1e-24 so the Weibull is technically
-    // valid but yields ~0% share → classifies as stalled automatically.
+    // Defensive fallback only — applyV1Recovery() should already have
+    // replaced v1=0 rows at load time with an anchor-reconstructed value.
+    // This branch fires only if a caller bypassed that step.
     if (!isFinite(v1)) continue;
     if (v1 === 0) v1 = -1e-24;
 


### PR DESCRIPTION
## Summary

- **Root cause:** the off-repo legacy "auto-publish model" R script reads `params.csv` with R defaults that round tiny `v1` values (≤ ~1e-7) to literal `0` on write-back. Indonesia fits to `v1 ≈ -6.1e-20` with `v2 ≈ 15.16`, so its row was getting silently clobbered between CI renders. The Durations table then patched `v1 = 0 → -1e-24` inside `inv_x_years`, which with `v2 ≈ 15` pushed the Weibull ~20 years into the future and reported a **~5-year 20→80 transition instead of the true ~2.3 years**. Re-rendering Indonesia "fixed" it for a while, then a subsequent local push reintroduced the bug — confirmed in Git history by alternating `chore: render Indonesia` ↔ `China: auto-publish model` commits throughout May 2026.
- **Frontend smart-recovery** (`index.html`) — every `v1 = 0` row is rewritten at load time by anchoring the Weibull at a `v2`-dependent BEV share at `data_per`: 28 % for `v2 ≥ 10` (Indonesia-style fast adopters, calibrated against the live fit), 50 % otherwise. **Reported 20→80 lands within ~1 day of the true fit** for Indonesia, vs the historical ~5-year garbage.
- **Backend self-heal** (`R/upsert.R::heal_v1_zero_rows`, invoked at the end of every render) — scans `params.csv` for the corruption fingerprint (`|v1| < 1e-25` AND `v2 ≥ 10`) and re-fits affected rows from `data/<Country>.csv` in place. Cheap when nothing's wrong; fully autonomous when something is. The very next CI render after any clobbering commit cleans the file.
- **No schema change** to `params.csv` — defence sits purely in code so external tools that aren't aware of it can't accidentally undo it. An explicit anchor column was considered and dropped for that reason; the 28 %-anchor heuristic plus the backend self-heal deliver the same user-visible accuracy in steady state.
- **Documented** in `docs/architecture/{README, 03-data-objects, 08-deploy-ops}.md` so the gotcha is grep-friendly from any direction; long-form runbook is at `08-deploy-ops.md § "Indonesia v1=0 corruption"`.

## Test plan

- [x] **Backend heal end-to-end:** corrupt Indonesia row in `params.csv` to `v1=0,-0`, run `heal_v1_zero_rows()` standalone — restores `v1=-6.1148e-20 v2=15.1628` exactly. Header stays 12-column (no surprise schema change).
- [x] **Backend heal idempotent:** running heal on a clean `params.csv` is a no-op (file read + numeric parse only).
- [x] **Frontend recovery math** (Node bench against live fit):
  - Corrupted (`v1=0`, old `-1e-24` patch): 20→80 = **4.82 yrs**, error **910 days**
  - Corrupted (`v1=0`, new v2-anchor): 20→80 = **2.33 yrs**, error **1 day**
  - Healthy Indonesia (`v1=-6.115e-20`): unchanged, 20→80 = 2.33 yrs
  - Healthy Germany: unchanged, 20→80 = 13.68 yrs
  - Missing `data_per`: falls back to legacy `-1e-24` constant
- [x] All six `parseCSV` consumers wired through `applyV1Recovery` (Thresholds, Durations, Builder, World Map, Fleet, plus `wmBuildRows` dedupe path).
- [x] `node --check` passes on the concatenated `<script>` blocks of `index.html`.
- [ ] Verify on the deployed page after merge: Indonesia row in Durations table reads ~2 yr 4 mo 20→80 even after the next local auto-publish.

https://claude.ai/code/session_01KvjscfzDDGTUtCtQSBMzYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvjscfzDDGTUtCtQSBMzYe)_