### PR TITLE
data: Singapore (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/Singapore.csv
+++ b/data/Singapore.csv
@@ -111,3 +111,4 @@ period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,note
 2026-01,monthly,Whole,data.gov.s / lta.gov.sg / robbieandrew,2355.0,106.0,1548.0,257.0,0.0,0.0,4266.0,
 2026-02,monthly,Whole,data.gov.s / lta.gov.sg / robbieandrew,2237.0,75.0,1369.0,326.0,0.0,0.0,4007.0,
 2026-03,monthly,Whole,data.gov.s / lta.gov.sg / robbieandrew,3087.0,84.0,1583.0,295.0,0.0,0.0,5049.0,
+2026-04,monthly,Whole,data.gov.s / lta.gov.sg / robbieandrew,2982,97,1243,230,1,0,4553,


### PR DESCRIPTION
Submitted by **Anonymous** via Submit Data form.

- **Country:** Singapore
- **Variant:** Whole
- **Source:** data.gov.s / lta.gov.sg / robbieandrew
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-04** (monthly) — BEV=2982, PHEV=97, HEV=1243, PETROL=230, DIESEL=1, OTHERS=0, TOTAL=4553

---

After merge, trigger the **Render country charts** Action to regenerate plots.