### PR TITLE
fix(chile): strip href whitespace so ANAC discovery survives newline-prefixed links

### DIFF
--- a/docs/architecture/05-flows.md
+++ b/docs/architecture/05-flows.md
@@ -340,6 +340,10 @@ sequenceDiagram
 
 **Why MHEV → ICE:** ANAC reports mild-hybrids (Microhíbridos) as a separate line that didn't exist historically and isn't in `data/Chile.csv`'s schema. Per maintainer's call we bucket them into ICE via the implicit subtraction (`ICE = TOTAL − BEV − PHEV − HEV − OTHERS`) rather than introducing a new column.
 
+### Issues hit in production
+
+1. **ANAC hrefs sometimes carry a leading newline.** The April 2026 cron failed three days in a row with `requests.exceptions.ConnectionError: HTTPSConnectionPool(host='www.anac.cl%0ahttps', …)`. Root cause: on the category listing page, ANAC's CMS emits some `<a href>` values as `"\nhttps://www.anac.cl/wp-content/uploads/…pdf"` (literal leading newline). The discovery loop's `href.startswith("http")` returned False on the unstripped value, so the script prepended the host — producing `"https://www.anac.cl\nhttps://www.anac.cl/…"`. `requests` URL-encoded the newline (`%0a`) into the hostname and the connection bombed before any PDF was touched. Fix: `href = a["href"].strip()` before the prefix check. The earlier months (Enero/Febrero/Marzo 2026) were ingested manually as part of the bootstrap, so the bug only surfaced once the cron tried to discover its first month live. Pre-existing pattern: see the same `host_not_allowed` and User-Agent stories in Flow J / ACEA — ANAC's WordPress in particular is whitespace-loose in its emitted HTML and we should treat any href we don't control as needing `.strip()` before structural checks.
+
 ## Flow J — JADA ingest
 
 Japan follows the same `fetch-<country>` pattern as Brazil and Chile, with two twists: (1) JADA publishes the data in **both** PDF and XLSX form — we prefer the XLSX because its cell layout is machine-readable; (2) each publication is a rolling **4-month rollup** (one sheet/page per month), not a single-month file. We extract the target month from whichever sheet matches and let older months pass through untouched. The cron runs daily from the 1st onward and the script self-throttles via the CSV's latest period — most invocations are a no-op until JADA publishes the file for the previous month (typically the first business week).

--- a/scripts/fetch_chile.py
+++ b/scripts/fetch_chile.py
@@ -174,7 +174,12 @@ def discover_pdfs(year: int, month: int) -> tuple[str | None, str | None]:
 
     mercado_url = emisiones_url = None
     for a in soup.find_all("a", href=True):
-        href = a["href"]
+        # ANAC occasionally renders hrefs with leading whitespace/newlines
+        # (seen in the wild: "\nhttps://www.anac.cl/wp-content/..."). Without
+        # this strip(), startswith("http") returns False and we'd prepend
+        # the host, producing "https://www.anac.cl\nhttps://..." → requests
+        # then raises ConnectionError on host 'www.anac.cl%0ahttps'.
+        href = a["href"].strip()
         if mercado_url is None and mercado_re.search(href):
             mercado_url = href if href.startswith("http") else "https://www.anac.cl" + href
         if emisiones_url is None and emisiones_re.search(href):


### PR DESCRIPTION
## Summary

- The Chile cron has been failing daily since 2026-05-19 with `requests.exceptions.ConnectionError: HTTPSConnectionPool(host='www.anac.cl%0ahttps', …)`.
- Root cause: ANAC's category page emits some `<a href>` values with a literal leading newline (`"\nhttps://www.anac.cl/wp-content/…pdf"`). `href.startswith("http")` returned False on the unstripped value, so `discover_pdfs` prepended the host — producing `"https://www.anac.cl\nhttps://…"` which `requests` URL-encoded into the hostname.
- Fix is one line: `href = a["href"].strip()` before the prefix check, with an inline comment recording the symptom so a future reader doesn't "clean up" the strip().
- Docs: added an "Issues hit in production" subsection to Flow I in `docs/architecture/05-flows.md`, matching the shape of the existing Flow J / ACEA sections.

The earlier months in `data/Chile.csv` (Enero/Febrero/Marzo 2026) were ingested as part of the bootstrap commit, so this bug only surfaced once the cron tried to discover its first month live.

## Test plan

- [x] Local repro of URL construction confirms the bug and the fix: with the strip, `"\nhttps://www.anac.cl/.../Abril-2026...pdf"` resolves to the clean URL.
- [ ] After merge, maintainer triggers `workflow_dispatch` manually to pick up April 2026.
- [ ] Verify `data/Chile.csv` gains a `2026-04` row and that `render-country.yml` is dispatched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApqxTpab1brULco8MZi5sD)_