### PR TITLE
fix(ci): unbreak render-country workflow (duplicate type: key from #43)

### DIFF
--- a/.github/workflows/render-country.yml
+++ b/.github/workflows/render-country.yml
@@ -34,7 +34,6 @@ on:
           - Industry
           - Private
           - Vans
-        type: string
   workflow_call:
     inputs:
       country:


### PR DESCRIPTION
## Summary

- PR #43 merged with a botched conflict resolution in `.github/workflows/render-country.yml`: the new `variant` dropdown (`type: choice`) was added but the prior `type: string` line wasn't removed, leaving two `type:` keys on the same input.
- Every manual dispatch on master since then has failed at queue time with:
  > Failed to queue workflow run: Invalid Argument - failed to parse workflow: (Line: 37, Col: 9): 'type' is already defined
- This drops the leftover `type: string` so `workflow_dispatch` gets the intended Whole/Used/HDV/Industry/Private/Vans dropdown back. The separate `workflow_call.variant` (used by `fetch-acea.yml` / `fetch-uruguay.yml`) remains `type: string` — `choice` isn't a permitted `workflow_call` input type.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/render-country.yml'))"` parses cleanly
- [ ] After merge: dispatch `Render country charts` from the Actions UI with `country=Netherlands`, `variant=Whole` and confirm the run queues
- [ ] Confirm the multi-country `fetch-acea.yml` matrix can still `workflow_call` render-country (variant stays string there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)