### PR TITLE
Prevent vertical scroll bounce on mobile tab bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -826,6 +826,8 @@ header h1::before{
   padding:6px max(18px, calc((100vw - var(--maxw)) / 2 + 18px)) 0;
   gap:22px;
   overflow-x:auto;
+  overflow-y:hidden;
+  overscroll-behavior-y:contain;
   flex-wrap:nowrap;
   background:rgba(10,13,16,.78);
   border-bottom:1px solid var(--line-soft);


### PR DESCRIPTION
The .tabs container set overflow-x:auto without specifying overflow-y.
Per CSS spec, when one axis is auto, the other computes to auto rather
than visible, which allowed the tab bar to scroll vertically on touch
devices. Lock overflow-y to hidden and contain overscroll so only
horizontal panning is possible.