### PR TITLE
feat(time-interval): rename Speed → Time Interval (user-facing)

### DIFF
--- a/docs/architecture/01-overview.md
+++ b/docs/architecture/01-overview.md
@@ -2,7 +2,7 @@
 
 ## What this project is
 
-A public-facing static site at <https://leraffl.github.io/LeRaffl-Gallery/> that publishes monthly extrapolations of the BEV / PHEV / ICE share of new vehicle registrations across ~43 countries, plus four canonical chart types per country, plus interactive tools (Builder, Thresholds, Durations, Speed, World Map, Fleet) backed by a model parameter file.
+A public-facing static site at <https://leraffl.github.io/LeRaffl-Gallery/> that publishes monthly extrapolations of the BEV / PHEV / ICE share of new vehicle registrations across ~43 countries, plus four canonical chart types per country, plus interactive tools (Builder, Thresholds, Durations, Time Interval, World Map, Fleet) backed by a model parameter file.
 
 Every chart is the output of a weighted regression on registration data the maintainer collects from national statistics offices. The same parameter set (`params.csv`) drives both the static images and the in-browser interactive tools — there is one source of truth for the model.
 

--- a/docs/architecture/02-components.md
+++ b/docs/architecture/02-components.md
@@ -60,7 +60,7 @@ A single ~6000-line HTML file with inline CSS and inline JavaScript. No build st
 | Gallery | `manifest.json` + `images/<period>/<slug>_*.png` | Grid of all PNGs filterable by country, type, period |
 | Thresholds | `params.csv` | When each country reaches 20%/50%/80% BEV under the current model |
 | Durations | `params.csv` | How many years each country needs to traverse 20→80% |
-| Speed | `params.csv` | Interval chart: horizontal bar per country from From%→To% BEV share, dot at Mid%; sortable by start/mid/end/duration, region encoded by color, variant (Whole / Private / Industry / HDV / Used / …) encoded by bar shape (solid / diagonal / cross-hatch / thick stripes / outline). Custom From/Mid/To inputs default to 20/50/80. PNG and SVG export with `@LeRaffl` tag, created timestamp (incl. time, UTC) and `data per <oldest> (<country>) – <newest>` footer. |
+| Time Interval | `params.csv` | Interval chart: horizontal bar per country from From%→To% BEV share, dot at Mid%; sortable by start/mid/end/duration, region encoded by color, variant (Whole / Private / Industry / HDV / Used / …) encoded by bar shape (solid / diagonal / cross-hatch / thick stripes / outline). Custom From/Mid/To inputs default to 20/50/80. PNG and SVG export with `@LeRaffl` tag, created timestamp (incl. time, UTC) and `data per <oldest> (<country>) – <newest>` footer. |
 | Builder | `params.csv` | Interactive "what-if" curves with adjustable v1/v2/t0 |
 | Fleet | `fleet/*.csv`, `fleet_meta.json` | Bestand projection (separate from new-registrations data) |
 | World Map | `params.csv` + `weights.csv` | Choropleth of current BEV share |

--- a/docs/architecture/03-data-objects.md
+++ b/docs/architecture/03-data-objects.md
@@ -147,7 +147,7 @@ Germany,Whole,-1.050261627753e-4,2.898020288277,2011,2026-04,2026-05-08,KBA,,-3.
 
 - **Author**: R Render Pipeline (`R/upsert.R::upsert_params`) on every render.
 - **Updated**: Line-level — only the touched `(country, variant)` row changes. The rest of the file stays byte-identical.
-- **Read by**: The Static Page for Builder, Thresholds, Durations, Speed, World Map tabs.
+- **Read by**: The Static Page for Builder, Thresholds, Durations, Time Interval, World Map tabs.
 
 ### Number formatting convention
 

--- a/docs/architecture/05-flows.md
+++ b/docs/architecture/05-flows.md
@@ -215,7 +215,7 @@ sequenceDiagram
         Pages-->>Browser: PNG
     end
     par (on tab switch)
-        Browser->>Pages: GET params.csv (Builder/Thresholds/Durations/Speed/Map)
+        Browser->>Pages: GET params.csv (Builder/Thresholds/Durations/TimeInterval/Map)
         Pages-->>Browser: CSV
     end
 ```

--- a/index.html
+++ b/index.html
@@ -1655,7 +1655,7 @@ a:focus-visible{
       <span class="tab-group-label">Rankings</span>
       <a href="#thresholds" class="tablink">Thresholds</a>
       <a href="#durations" class="tablink">Durations</a>
-      <a href="#speed" class="tablink">Speed</a>
+      <a href="#speed" class="tablink">Time Interval</a>
     </span>
     <span class="tab-group">
       <span class="tab-group-label">DIY Curves</span>
@@ -2059,7 +2059,7 @@ a:focus-visible{
   <!-- SPEED TAB (20–80% transition interval plot) -->
   <section id="tab-speed" class="tab">
     <div class="container">
-      <h2>Transition Speed
+      <h2>Transition Time Interval
         <span class="fb-ctx-cluster" data-fb-context='{"section":"heading"}'>
           <button class="fb-ctx-btn" data-cat="data"     title="Report a data error">⚠️</button>
           <button class="fb-ctx-btn" data-cat="bug"      title="Report a bug">🐛</button>
@@ -4128,7 +4128,7 @@ renderTable();
     // Title block
     svg.appendChild(svgEl('text',{
       x:padLeft, y:28, fill:'#e9eef2','font-size':'18','font-weight':'600'
-    }, 'Speed of the BEV transition by country'));
+    }, 'BEV transition time interval by country'));
     svg.appendChild(svgEl('text',{
       x:padLeft, y:50, fill:'#9fb3d1','font-size':'12'
     }, `Bars: ${opts.fromPct}% → ${opts.toPct}% BEV share · dot marks ${opts.midPct}% · sorted by ${opts.sortKey}`));
@@ -4320,14 +4320,14 @@ renderTable();
       document.getElementById('speedExportPng').addEventListener('click', ()=>{
         const svg=document.querySelector('#speedMount svg');
         if(!svg) return;
-        svgToPngBlob(svg, 2).then(b=>downloadBlob(b, stampedFilename('bev_speed.png')))
+        svgToPngBlob(svg, 2).then(b=>downloadBlob(b, stampedFilename('bev_time_interval.png')))
           .catch(err=>console.warn('PNG export failed:', err));
       });
       document.getElementById('speedExportSvg').addEventListener('click', ()=>{
         const svg=document.querySelector('#speedMount svg');
         if(!svg) return;
         const xml=new XMLSerializer().serializeToString(svg);
-        downloadBlob(new Blob([xml],{type:'image/svg+xml;charset=utf-8'}), stampedFilename('bev_speed.svg'));
+        downloadBlob(new Blob([xml],{type:'image/svg+xml;charset=utf-8'}), stampedFilename('bev_time_interval.svg'));
       });
       window.addEventListener('resize', (()=>{
         let t; return ()=>{ clearTimeout(t); t=setTimeout(redraw,200); };


### PR DESCRIPTION
## Summary
Follow-up to #46. The new tab is more accurately "time interval between thresholds" than "speed" — speed is a derivative (years⁻¹), and the Durations tab already covers the slope-at-inflection metric. Rename the user-visible label so the meaning matches.

Internal IDs (`#speed`, `tab-speed`, `speedMount`, JS variable names) stay as-is to keep the diff small and avoid touching the JS module wholesale; only what's actually rendered to the user changes.

- Nav label: **Speed** → **Time Interval**
- Section heading: *Transition Speed* → *Transition Time Interval*
- SVG chart title: *Speed of the BEV transition by country* → *BEV transition time interval by country*
- Export filenames: `bev_speed.{png,svg}` → `bev_time_interval.{png,svg}`
- Docs updated in `01-overview.md`, `02-components.md`, `03-data-objects.md`, `05-flows.md`

## Base branch
This PR targets **`feat/speed-tab`** (the still-open PR #46). Once #46 merges into master, GitHub will auto-rebase this one onto master.

## Test plan
- [ ] `#speed` deep-link still works (id unchanged) and shows the renamed label in nav.
- [ ] PNG and SVG downloads use the new filename.
- [ ] Tab heading reads *Transition Time Interval*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)