### PR TITLE
fix(submit-data): include ICE in category sumcheck

### DIFF
--- a/index.html
+++ b/index.html
@@ -7671,7 +7671,7 @@ function sdUpdateSumcheck(node) {
   const el = node.querySelector('[data-sumcheck]');
   if (fuels.TOTAL === undefined) { el.textContent = ''; el.className = 'sd-row-sumcheck'; return; }
 
-  const cats = ['BEV','PHEV','EREV','HEV','MHEV','PETROL','DIESEL','GAS','CNG','LPG','FLEXFUEL','ETHANOL','OTHERS'];
+  const cats = ['BEV','PHEV','EREV','HEV','MHEV','PETROL','DIESEL','GAS','CNG','LPG','FLEXFUEL','ETHANOL','OTHERS','ICE'];
   const sum = cats.reduce((s, k) => s + (fuels[k] || 0), 0);
   const total = fuels.TOTAL;
   const diff = sum - total;


### PR DESCRIPTION
## Summary
- Client-side sumcheck under each Submit Data row now includes `ICE` when comparing the category sum against `TOTAL`.
- Fixes the spurious *"off by X%, please double-check"* warning seen on South Korea submissions (where the difference exactly matched the ICE value).

## Why
The Korea CSV uses the `ICE` schema column. Before this fix, ICE was rendered as an input but omitted from the in-form sanity check, so a perfectly consistent row looked broken to the submitter.

## Note (out of scope)
The deployed Cloudflare Worker still rejects ICE with \`unknown fuel column \"ICE\"\` — the source in \`worker/index.js\` already accepts ICE (since #15), the live Worker just needs a redeploy. Not included in this PR.

## Test plan
- [ ] Open Submit Data → South Korea, enter the April 2026 row with ICE filled, confirm the sumcheck now matches TOTAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)