### PR TITLE
fix(manifest): unify multi-word country labels (South Korea, New Zealand, …)

### DIFF
--- a/build_manifest.R
+++ b/build_manifest.R
@@ -37,20 +37,50 @@ to_title_keep_digits <- function(x) {
 
 label_from_slug <- function(slug, country_overrides = NULL, variant_overrides = NULL){
   s <- tolower(slug)
-  
-  # Basisland = alles bis erstes "_"
-  base <- sub("^([a-z0-9-]+).*$", "\\1", s)
-  
-  # Länder-Overrides (Diakritika etc.)
-  country_map <- c("tuerkiye" = "Türkiye", "uk" = "UK", "usa" = "USA")
+
+  # Länder-Overrides (Diakritika + Multi-Word-Slugs wie "south_korea").
+  # Multi-Word-Einträge MÜSSEN hier registriert sein, sonst splittet die
+  # Heuristik unten am ersten "_" und macht aus "south_korea" fälschlich
+  # "South (Korea)".
+  country_map <- c(
+    "tuerkiye"     = "Türkiye",
+    "uk"           = "UK",
+    "usa"          = "USA",
+    "south_korea"  = "South Korea",
+    "southkorea"   = "South Korea",
+    "new_zealand"  = "New Zealand",
+    "saudi_arabia" = "Saudi Arabia",
+    "south_africa" = "South Africa",
+    "hong_kong"    = "Hong Kong",
+    "czech_republic" = "Czech Republic",
+    "united_kingdom" = "United Kingdom",
+    "united_states"  = "United States"
+  )
   if (!is.null(country_overrides)) {
     country_map[names(country_overrides)] <- country_overrides
   }
-  
+
+  # Multi-Word-Länder zuerst matchen (Präfix-Match auf dem ganzen Slug),
+  # damit "south_korea_hdv" zu base="south_korea", rest="hdv" wird statt
+  # base="south", rest="korea_hdv".
+  multi <- names(country_map)[grepl("_", names(country_map))]
+  multi_match <- vapply(s, function(x){
+    hit <- multi[startsWith(x, multi) &
+                 (nchar(x) == nchar(multi) | substr(x, nchar(multi) + 1, nchar(multi) + 1) == "_")]
+    if (length(hit)) hit[which.max(nchar(hit))] else NA_character_
+  }, character(1))
+
+  # Basisland = Multi-Word-Treffer ODER alles bis erstes "_"
+  base <- ifelse(!is.na(multi_match),
+                 multi_match,
+                 sub("^([a-z0-9-]+).*$", "\\1", s))
+
   base_label <- ifelse(!is.na(country_map[base]), country_map[base], stringr::str_to_title(base))
-  
-  # Variante = alles nach erstem "_"
-  rest <- sub("^[a-z0-9-]+_?", "", s)
+
+  # Variante = alles nach dem Basisland (mit oder ohne "_")
+  rest <- mapply(function(x, b){
+    sub(paste0("^", b, "_?"), "", x)
+  }, s, base, USE.NAMES = FALSE)
   
   # Normalisierung Rest (vektorisiert). str_to_title runs first because it
   # lowercases its input; abbreviation upper-casing (HDV/HEV/PHEV/EV) must

--- a/build_manifest.R
+++ b/build_manifest.R
@@ -46,15 +46,28 @@ label_from_slug <- function(slug, country_overrides = NULL, variant_overrides = 
     "tuerkiye"     = "Türkiye",
     "uk"           = "UK",
     "usa"          = "USA",
-    "south_korea"  = "South Korea",
-    "southkorea"   = "South Korea",
-    "new_zealand"  = "New Zealand",
-    "saudi_arabia" = "Saudi Arabia",
-    "south_africa" = "South Africa",
-    "hong_kong"    = "Hong Kong",
-    "czech_republic" = "Czech Republic",
-    "united_kingdom" = "United Kingdom",
-    "united_states"  = "United States"
+    # Multi-Word-Slugs (underscore). Reihenfolge egal, längster Präfix
+    # gewinnt im Match unten.
+    "south_korea"     = "South Korea",
+    "new_zealand"     = "New Zealand",
+    "saudi_arabia"    = "Saudi Arabia",
+    "south_africa"    = "South Africa",
+    "hong_kong"       = "Hong Kong",
+    "czech_republic"  = "Czech Republic",
+    "united_kingdom"  = "United Kingdom",
+    "united_states"   = "United States",
+    # Legacy-Single-Word-Slugs aus früheren Renders. Bleiben hier, damit
+    # die alten PNGs nicht umbenannt werden müssen und trotzdem unter
+    # demselben Display-Label wie die neuen Slugs landen → keine
+    # Doppelung im Country-Dropdown.
+    "southkorea"      = "South Korea",
+    "newzealand"      = "New Zealand",
+    "saudiarabia"     = "Saudi Arabia",
+    "southafrica"     = "South Africa",
+    "hongkong"        = "Hong Kong",
+    "czechrepublic"   = "Czech Republic",
+    "unitedkingdom"   = "United Kingdom",
+    "unitedstates"    = "United States"
   )
   if (!is.null(country_overrides)) {
     country_map[names(country_overrides)] <- country_overrides

--- a/manifest.json
+++ b/manifest.json
@@ -82,43 +82,43 @@
       "country_slug": "china"
     },
     {
-      "country": "South (Korea)",
+      "country": "South Korea",
       "type": "ICE_BEV",
       "period": "2026-04",
       "date": "2026-05-25",
       "filename": "south_korea_ICE_BEV_20260525.png",
       "url": "images/2026-04/south_korea_ICE_BEV_20260525.png",
-      "alt": "South (Korea) ICE-BEV-Hybrid trajectory",
+      "alt": "South Korea ICE-BEV-Hybrid trajectory",
       "country_slug": "south_korea"
     },
     {
-      "country": "South (Korea)",
+      "country": "South Korea",
       "type": "share",
       "period": "2026-04",
       "date": "2026-05-25",
       "filename": "south_korea_20260525.png",
       "url": "images/2026-04/south_korea_20260525.png",
-      "alt": "South (Korea) BEV trajectory",
+      "alt": "South Korea BEV trajectory",
       "country_slug": "south_korea"
     },
     {
-      "country": "South (Korea)",
+      "country": "South Korea",
       "type": "time",
       "period": "2026-04",
       "date": "2026-05-25",
       "filename": "south_korea_time_20260525.png",
       "url": "images/2026-04/south_korea_time_20260525.png",
-      "alt": "South (Korea) Transition time curve",
+      "alt": "South Korea Transition time curve",
       "country_slug": "south_korea"
     },
     {
-      "country": "South (Korea)",
+      "country": "South Korea",
       "type": "ttm_shares",
       "period": "2026-04",
       "date": "2026-05-25",
       "filename": "south_korea_ttm_shares_20260525.png",
       "url": "images/2026-04/south_korea_ttm_shares_20260525.png",
-      "alt": "South (Korea) TTM market split graph",
+      "alt": "South Korea TTM market split graph",
       "country_slug": "south_korea"
     },
     {
@@ -832,43 +832,43 @@
       "country_slug": "italy"
     },
     {
-      "country": "New (Zealand)",
+      "country": "New Zealand",
       "type": "ICE_BEV",
       "period": "2026-04",
       "date": "2026-05-09",
       "filename": "new_zealand_ICE_BEV_20260509.png",
       "url": "images/2026-04/new_zealand_ICE_BEV_20260509.png",
-      "alt": "New (Zealand) ICE-BEV-Hybrid trajectory",
+      "alt": "New Zealand ICE-BEV-Hybrid trajectory",
       "country_slug": "new_zealand"
     },
     {
-      "country": "New (Zealand)",
+      "country": "New Zealand",
       "type": "share",
       "period": "2026-04",
       "date": "2026-05-09",
       "filename": "new_zealand_20260509.png",
       "url": "images/2026-04/new_zealand_20260509.png",
-      "alt": "New (Zealand) BEV trajectory",
+      "alt": "New Zealand BEV trajectory",
       "country_slug": "new_zealand"
     },
     {
-      "country": "New (Zealand)",
+      "country": "New Zealand",
       "type": "time",
       "period": "2026-04",
       "date": "2026-05-09",
       "filename": "new_zealand_time_20260509.png",
       "url": "images/2026-04/new_zealand_time_20260509.png",
-      "alt": "New (Zealand) Transition time curve",
+      "alt": "New Zealand Transition time curve",
       "country_slug": "new_zealand"
     },
     {
-      "country": "New (Zealand)",
+      "country": "New Zealand",
       "type": "ttm_shares",
       "period": "2026-04",
       "date": "2026-05-09",
       "filename": "new_zealand_ttm_shares_20260509.png",
       "url": "images/2026-04/new_zealand_ttm_shares_20260509.png",
-      "alt": "New (Zealand) TTM market split graph",
+      "alt": "New Zealand TTM market split graph",
       "country_slug": "new_zealand"
     },
     {
@@ -1392,43 +1392,43 @@
       "country_slug": "romania"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "ICE_BEV",
       "period": "2026-03",
       "date": "2026-04-28",
       "filename": "southkorea_ICE_BEV_20260428.png",
       "url": "images/2026-03/southkorea_ICE_BEV_20260428.png",
-      "alt": "Southkorea ICE-BEV-Hybrid trajectory",
+      "alt": "South Korea ICE-BEV-Hybrid trajectory",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "share",
       "period": "2026-03",
       "date": "2026-04-28",
       "filename": "southkorea_20260428.png",
       "url": "images/2026-03/southkorea_20260428.png",
-      "alt": "Southkorea BEV trajectory",
+      "alt": "South Korea BEV trajectory",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "time",
       "period": "2026-03",
       "date": "2026-04-28",
       "filename": "southkorea_time_20260428.png",
       "url": "images/2026-03/southkorea_time_20260428.png",
-      "alt": "Southkorea Transition time curve",
+      "alt": "South Korea Transition time curve",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "ttm_shares",
       "period": "2026-03",
       "date": "2026-04-28",
       "filename": "southkorea_ttm_shares_20260428.png",
       "url": "images/2026-03/southkorea_ttm_shares_20260428.png",
-      "alt": "Southkorea TTM market split graph",
+      "alt": "South Korea TTM market split graph",
       "country_slug": "southkorea"
     },
     {
@@ -3452,83 +3452,83 @@
       "country_slug": "japan"
     },
     {
-      "country": "Newzealand",
+      "country": "New Zealand",
       "type": "ICE_BEV",
       "period": "2026-03",
       "date": "2026-04-06",
       "filename": "newzealand_ICE_BEV_20260406.png",
       "url": "images/2026-03/newzealand_ICE_BEV_20260406.png",
-      "alt": "Newzealand ICE-BEV-Hybrid trajectory",
+      "alt": "New Zealand ICE-BEV-Hybrid trajectory",
       "country_slug": "newzealand"
     },
     {
-      "country": "Newzealand",
+      "country": "New Zealand",
       "type": "share",
       "period": "2026-03",
       "date": "2026-04-06",
       "filename": "newzealand_20260406.png",
       "url": "images/2026-03/newzealand_20260406.png",
-      "alt": "Newzealand BEV trajectory",
+      "alt": "New Zealand BEV trajectory",
       "country_slug": "newzealand"
     },
     {
-      "country": "Newzealand",
+      "country": "New Zealand",
       "type": "time",
       "period": "2026-03",
       "date": "2026-04-06",
       "filename": "newzealand_time_20260406.png",
       "url": "images/2026-03/newzealand_time_20260406.png",
-      "alt": "Newzealand Transition time curve",
+      "alt": "New Zealand Transition time curve",
       "country_slug": "newzealand"
     },
     {
-      "country": "Newzealand",
+      "country": "New Zealand",
       "type": "ttm_shares",
       "period": "2026-03",
       "date": "2026-04-06",
       "filename": "newzealand_ttm_shares_20260406.png",
       "url": "images/2026-03/newzealand_ttm_shares_20260406.png",
-      "alt": "Newzealand TTM market split graph",
+      "alt": "New Zealand TTM market split graph",
       "country_slug": "newzealand"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ICE_BEV",
       "period": "2026-03",
       "date": "2026-04-06",
       "filename": "newzealand_legacy_ICE_BEV_20260406.png",
       "url": "images/2026-03/newzealand_legacy_ICE_BEV_20260406.png",
-      "alt": "Newzealand (Legacy) ICE-BEV-Hybrid trajectory",
+      "alt": "New Zealand (Legacy) ICE-BEV-Hybrid trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "share",
       "period": "2026-03",
       "date": "2026-04-06",
       "filename": "newzealand_legacy_20260406.png",
       "url": "images/2026-03/newzealand_legacy_20260406.png",
-      "alt": "Newzealand (Legacy) BEV trajectory",
+      "alt": "New Zealand (Legacy) BEV trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "time",
       "period": "2026-03",
       "date": "2026-04-06",
       "filename": "newzealand_legacy_time_20260406.png",
       "url": "images/2026-03/newzealand_legacy_time_20260406.png",
-      "alt": "Newzealand (Legacy) Transition time curve",
+      "alt": "New Zealand (Legacy) Transition time curve",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ttm_shares",
       "period": "2026-03",
       "date": "2026-04-06",
       "filename": "newzealand_legacy_ttm_shares_20260406.png",
       "url": "images/2026-03/newzealand_legacy_ttm_shares_20260406.png",
-      "alt": "Newzealand (Legacy) TTM market split graph",
+      "alt": "New Zealand (Legacy) TTM market split graph",
       "country_slug": "newzealand_legacy"
     },
     {
@@ -5592,43 +5592,43 @@
       "country_slug": "singapore"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "ICE_BEV",
       "period": "2026-02",
       "date": "2026-03-21",
       "filename": "southkorea_ICE_BEV_20260321.png",
       "url": "images/2026-02/southkorea_ICE_BEV_20260321.png",
-      "alt": "Southkorea ICE-BEV-Hybrid trajectory",
+      "alt": "South Korea ICE-BEV-Hybrid trajectory",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "share",
       "period": "2026-02",
       "date": "2026-03-21",
       "filename": "southkorea_20260321.png",
       "url": "images/2026-02/southkorea_20260321.png",
-      "alt": "Southkorea BEV trajectory",
+      "alt": "South Korea BEV trajectory",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "time",
       "period": "2026-02",
       "date": "2026-03-21",
       "filename": "southkorea_time_20260321.png",
       "url": "images/2026-02/southkorea_time_20260321.png",
-      "alt": "Southkorea Transition time curve",
+      "alt": "South Korea Transition time curve",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "ttm_shares",
       "period": "2026-02",
       "date": "2026-03-21",
       "filename": "southkorea_ttm_shares_20260321.png",
       "url": "images/2026-02/southkorea_ttm_shares_20260321.png",
-      "alt": "Southkorea TTM market split graph",
+      "alt": "South Korea TTM market split graph",
       "country_slug": "southkorea"
     },
     {
@@ -6192,43 +6192,43 @@
       "country_slug": "australia"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ICE_BEV",
       "period": "2026-02",
       "date": "2026-03-09",
       "filename": "newzealand_legacy_ICE_BEV_20260309.png",
       "url": "images/2026-02/newzealand_legacy_ICE_BEV_20260309.png",
-      "alt": "Newzealand (Legacy) ICE-BEV-Hybrid trajectory",
+      "alt": "New Zealand (Legacy) ICE-BEV-Hybrid trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "share",
       "period": "2026-02",
       "date": "2026-03-09",
       "filename": "newzealand_legacy_20260309.png",
       "url": "images/2026-02/newzealand_legacy_20260309.png",
-      "alt": "Newzealand (Legacy) BEV trajectory",
+      "alt": "New Zealand (Legacy) BEV trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "time",
       "period": "2026-02",
       "date": "2026-03-09",
       "filename": "newzealand_legacy_time_20260309.png",
       "url": "images/2026-02/newzealand_legacy_time_20260309.png",
-      "alt": "Newzealand (Legacy) Transition time curve",
+      "alt": "New Zealand (Legacy) Transition time curve",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ttm_shares",
       "period": "2026-02",
       "date": "2026-03-09",
       "filename": "newzealand_legacy_ttm_shares_20260309.png",
       "url": "images/2026-02/newzealand_legacy_ttm_shares_20260309.png",
-      "alt": "Newzealand (Legacy) TTM market split graph",
+      "alt": "New Zealand (Legacy) TTM market split graph",
       "country_slug": "newzealand_legacy"
     },
     {
@@ -7742,43 +7742,43 @@
       "country_slug": "finland"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ICE_BEV",
       "period": "2026-01",
       "date": "2026-02-09",
       "filename": "newzealand_legacy_ICE_BEV_20260209.png",
       "url": "images/2026-01/newzealand_legacy_ICE_BEV_20260209.png",
-      "alt": "Newzealand (Legacy) ICE-BEV-Hybrid trajectory",
+      "alt": "New Zealand (Legacy) ICE-BEV-Hybrid trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "share",
       "period": "2026-01",
       "date": "2026-02-09",
       "filename": "newzealand_legacy_20260209.png",
       "url": "images/2026-01/newzealand_legacy_20260209.png",
-      "alt": "Newzealand (Legacy) BEV trajectory",
+      "alt": "New Zealand (Legacy) BEV trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "time",
       "period": "2026-01",
       "date": "2026-02-09",
       "filename": "newzealand_legacy_time_20260209.png",
       "url": "images/2026-01/newzealand_legacy_time_20260209.png",
-      "alt": "Newzealand (Legacy) Transition time curve",
+      "alt": "New Zealand (Legacy) Transition time curve",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ttm_shares",
       "period": "2026-01",
       "date": "2026-02-09",
       "filename": "newzealand_legacy_ttm_shares_20260209.png",
       "url": "images/2026-01/newzealand_legacy_ttm_shares_20260209.png",
-      "alt": "Newzealand (Legacy) TTM market split graph",
+      "alt": "New Zealand (Legacy) TTM market split graph",
       "country_slug": "newzealand_legacy"
     },
     {
@@ -8572,43 +8572,43 @@
       "country_slug": "slovenia"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "ICE_BEV",
       "period": "2025-12",
       "date": "2026-01-31",
       "filename": "southkorea_ICE_BEV_20260131.png",
       "url": "images/2025-12/southkorea_ICE_BEV_20260131.png",
-      "alt": "Southkorea ICE-BEV-Hybrid trajectory",
+      "alt": "South Korea ICE-BEV-Hybrid trajectory",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "share",
       "period": "2025-12",
       "date": "2026-01-31",
       "filename": "southkorea_20260131.png",
       "url": "images/2025-12/southkorea_20260131.png",
-      "alt": "Southkorea BEV trajectory",
+      "alt": "South Korea BEV trajectory",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "time",
       "period": "2025-12",
       "date": "2026-01-31",
       "filename": "southkorea_time_20260131.png",
       "url": "images/2025-12/southkorea_time_20260131.png",
-      "alt": "Southkorea Transition time curve",
+      "alt": "South Korea Transition time curve",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "ttm_shares",
       "period": "2025-12",
       "date": "2026-01-31",
       "filename": "southkorea_ttm_shares_20260131.png",
       "url": "images/2025-12/southkorea_ttm_shares_20260131.png",
-      "alt": "Southkorea TTM market split graph",
+      "alt": "South Korea TTM market split graph",
       "country_slug": "southkorea"
     },
     {
@@ -9922,43 +9922,43 @@
       "country_slug": "latvia"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ICE_BEV",
       "period": "2025-12",
       "date": "2026-01-17",
       "filename": "newzealand_legacy_ICE_BEV_20260117.png",
       "url": "images/2025-12/newzealand_legacy_ICE_BEV_20260117.png",
-      "alt": "Newzealand (Legacy) ICE-BEV-Hybrid trajectory",
+      "alt": "New Zealand (Legacy) ICE-BEV-Hybrid trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "share",
       "period": "2025-12",
       "date": "2026-01-17",
       "filename": "newzealand_legacy_20260117.png",
       "url": "images/2025-12/newzealand_legacy_20260117.png",
-      "alt": "Newzealand (Legacy) BEV trajectory",
+      "alt": "New Zealand (Legacy) BEV trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "time",
       "period": "2025-12",
       "date": "2026-01-17",
       "filename": "newzealand_legacy_time_20260117.png",
       "url": "images/2025-12/newzealand_legacy_time_20260117.png",
-      "alt": "Newzealand (Legacy) Transition time curve",
+      "alt": "New Zealand (Legacy) Transition time curve",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ttm_shares",
       "period": "2025-12",
       "date": "2026-01-17",
       "filename": "newzealand_legacy_ttm_shares_20260117.png",
       "url": "images/2025-12/newzealand_legacy_ttm_shares_20260117.png",
-      "alt": "Newzealand (Legacy) TTM market split graph",
+      "alt": "New Zealand (Legacy) TTM market split graph",
       "country_slug": "newzealand_legacy"
     },
     {
@@ -10002,43 +10002,43 @@
       "country_slug": "norway"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "ICE_BEV",
       "period": "2025-10",
       "date": "2026-01-17",
       "filename": "southkorea_ICE_BEV_20260117.png",
       "url": "images/2025-10/southkorea_ICE_BEV_20260117.png",
-      "alt": "Southkorea ICE-BEV-Hybrid trajectory",
+      "alt": "South Korea ICE-BEV-Hybrid trajectory",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "share",
       "period": "2025-10",
       "date": "2026-01-17",
       "filename": "southkorea_20260117.png",
       "url": "images/2025-10/southkorea_20260117.png",
-      "alt": "Southkorea BEV trajectory",
+      "alt": "South Korea BEV trajectory",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "time",
       "period": "2025-10",
       "date": "2026-01-17",
       "filename": "southkorea_time_20260117.png",
       "url": "images/2025-10/southkorea_time_20260117.png",
-      "alt": "Southkorea Transition time curve",
+      "alt": "South Korea Transition time curve",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "ttm_shares",
       "period": "2025-10",
       "date": "2026-01-17",
       "filename": "southkorea_ttm_shares_20260117.png",
       "url": "images/2025-10/southkorea_ttm_shares_20260117.png",
-      "alt": "Southkorea TTM market split graph",
+      "alt": "South Korea TTM market split graph",
       "country_slug": "southkorea"
     },
     {
@@ -12752,43 +12752,43 @@
       "country_slug": "india_4-wheelers"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "ICE_BEV",
       "period": "2025-10",
       "date": "2026-01-03",
       "filename": "southkorea_ICE_BEV_20260103.png",
       "url": "images/2025-10/southkorea_ICE_BEV_20260103.png",
-      "alt": "Southkorea ICE-BEV-Hybrid trajectory",
+      "alt": "South Korea ICE-BEV-Hybrid trajectory",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "share",
       "period": "2025-10",
       "date": "2026-01-03",
       "filename": "southkorea_20260103.png",
       "url": "images/2025-10/southkorea_20260103.png",
-      "alt": "Southkorea BEV trajectory",
+      "alt": "South Korea BEV trajectory",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "time",
       "period": "2025-10",
       "date": "2026-01-03",
       "filename": "southkorea_time_20260103.png",
       "url": "images/2025-10/southkorea_time_20260103.png",
-      "alt": "Southkorea Transition time curve",
+      "alt": "South Korea Transition time curve",
       "country_slug": "southkorea"
     },
     {
-      "country": "Southkorea",
+      "country": "South Korea",
       "type": "ttm_shares",
       "period": "2025-10",
       "date": "2026-01-03",
       "filename": "southkorea_ttm_shares_20260103.png",
       "url": "images/2025-10/southkorea_ttm_shares_20260103.png",
-      "alt": "Southkorea TTM market split graph",
+      "alt": "South Korea TTM market split graph",
       "country_slug": "southkorea"
     },
     {
@@ -16012,43 +16012,43 @@
       "country_slug": "luxembourg"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ICE_BEV",
       "period": "2025-11",
       "date": "2025-12-13",
       "filename": "newzealand_legacy_ICE_BEV_20251213.png",
       "url": "images/2025-11/newzealand_legacy_ICE_BEV_20251213.png",
-      "alt": "Newzealand (Legacy) ICE-BEV-Hybrid trajectory",
+      "alt": "New Zealand (Legacy) ICE-BEV-Hybrid trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "share",
       "period": "2025-11",
       "date": "2025-12-13",
       "filename": "newzealand_legacy_20251213.png",
       "url": "images/2025-11/newzealand_legacy_20251213.png",
-      "alt": "Newzealand (Legacy) BEV trajectory",
+      "alt": "New Zealand (Legacy) BEV trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "time",
       "period": "2025-11",
       "date": "2025-12-13",
       "filename": "newzealand_legacy_time_20251213.png",
       "url": "images/2025-11/newzealand_legacy_time_20251213.png",
-      "alt": "Newzealand (Legacy) Transition time curve",
+      "alt": "New Zealand (Legacy) Transition time curve",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ttm_shares",
       "period": "2025-11",
       "date": "2025-12-13",
       "filename": "newzealand_legacy_ttm_shares_20251213.png",
       "url": "images/2025-11/newzealand_legacy_ttm_shares_20251213.png",
-      "alt": "Newzealand (Legacy) TTM market split graph",
+      "alt": "New Zealand (Legacy) TTM market split graph",
       "country_slug": "newzealand_legacy"
     },
     {
@@ -19152,43 +19152,43 @@
       "country_slug": "australia"
     },
     {
-      "country": "Newzealand",
+      "country": "New Zealand",
       "type": "ICE_BEV",
       "period": "2025-09",
       "date": "2025-10-04",
       "filename": "newzealand_ICE_BEV_20251004.png",
       "url": "images/2025-09/newzealand_ICE_BEV_20251004.png",
-      "alt": "Newzealand ICE-BEV-Hybrid trajectory",
+      "alt": "New Zealand ICE-BEV-Hybrid trajectory",
       "country_slug": "newzealand"
     },
     {
-      "country": "Newzealand",
+      "country": "New Zealand",
       "type": "share",
       "period": "2025-09",
       "date": "2025-10-04",
       "filename": "newzealand_20251004.png",
       "url": "images/2025-09/newzealand_20251004.png",
-      "alt": "Newzealand BEV trajectory",
+      "alt": "New Zealand BEV trajectory",
       "country_slug": "newzealand"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "time",
       "period": "2025-09",
       "date": "2025-10-04",
       "filename": "newzealand_legacy_time_20251004.png",
       "url": "images/2025-09/newzealand_legacy_time_20251004.png",
-      "alt": "Newzealand (Legacy) Transition time curve",
+      "alt": "New Zealand (Legacy) Transition time curve",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ttm_shares",
       "period": "2025-09",
       "date": "2025-10-04",
       "filename": "newzealand_legacy_ttm_shares_20251004.png",
       "url": "images/2025-09/newzealand_legacy_ttm_shares_20251004.png",
-      "alt": "Newzealand (Legacy) TTM market split graph",
+      "alt": "New Zealand (Legacy) TTM market split graph",
       "country_slug": "newzealand_legacy"
     },
     {
@@ -19232,43 +19232,43 @@
       "country_slug": "usa"
     },
     {
-      "country": "Newzealand",
+      "country": "New Zealand",
       "type": "ICE_BEV",
       "period": "2025-09",
       "date": "2025-10-03",
       "filename": "newzealand_ICE_BEV_20251003.png",
       "url": "images/2025-09/newzealand_ICE_BEV_20251003.png",
-      "alt": "Newzealand ICE-BEV-Hybrid trajectory",
+      "alt": "New Zealand ICE-BEV-Hybrid trajectory",
       "country_slug": "newzealand"
     },
     {
-      "country": "Newzealand",
+      "country": "New Zealand",
       "type": "share",
       "period": "2025-09",
       "date": "2025-10-03",
       "filename": "newzealand_20251003.png",
       "url": "images/2025-09/newzealand_20251003.png",
-      "alt": "Newzealand BEV trajectory",
+      "alt": "New Zealand BEV trajectory",
       "country_slug": "newzealand"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "time",
       "period": "2025-09",
       "date": "2025-10-03",
       "filename": "newzealand_legacy_time_20251003.png",
       "url": "images/2025-09/newzealand_legacy_time_20251003.png",
-      "alt": "Newzealand (Legacy) Transition time curve",
+      "alt": "New Zealand (Legacy) Transition time curve",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ttm_shares",
       "period": "2025-09",
       "date": "2025-10-03",
       "filename": "newzealand_legacy_ttm_shares_20251003.png",
       "url": "images/2025-09/newzealand_legacy_ttm_shares_20251003.png",
-      "alt": "Newzealand (Legacy) TTM market split graph",
+      "alt": "New Zealand (Legacy) TTM market split graph",
       "country_slug": "newzealand_legacy"
     },
     {
@@ -20552,43 +20552,43 @@
       "country_slug": "ireland"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ICE_BEV",
       "period": "2025-06",
       "date": "2025-07-10",
       "filename": "newzealand_legacy_ICE_BEV_20250710.png",
       "url": "images/2025-06/newzealand_legacy_ICE_BEV_20250710.png",
-      "alt": "Newzealand (Legacy) ICE-BEV-Hybrid trajectory",
+      "alt": "New Zealand (Legacy) ICE-BEV-Hybrid trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "share",
       "period": "2025-06",
       "date": "2025-07-10",
       "filename": "newzealand_legacy_20250710.png",
       "url": "images/2025-06/newzealand_legacy_20250710.png",
-      "alt": "Newzealand (Legacy) BEV trajectory",
+      "alt": "New Zealand (Legacy) BEV trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "time",
       "period": "2025-06",
       "date": "2025-07-10",
       "filename": "newzealand_legacy_time_20250710.png",
       "url": "images/2025-06/newzealand_legacy_time_20250710.png",
-      "alt": "Newzealand (Legacy) Transition time curve",
+      "alt": "New Zealand (Legacy) Transition time curve",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ttm_shares",
       "period": "2025-06",
       "date": "2025-07-10",
       "filename": "newzealand_legacy_ttm_shares_20250710.png",
       "url": "images/2025-06/newzealand_legacy_ttm_shares_20250710.png",
-      "alt": "Newzealand (Legacy) TTM market split graph",
+      "alt": "New Zealand (Legacy) TTM market split graph",
       "country_slug": "newzealand_legacy"
     },
     {
@@ -21942,43 +21942,43 @@
       "country_slug": "luxembourg"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ICE_BEV",
       "period": "2025-05",
       "date": "2025-06-05",
       "filename": "newzealand_legacy_ICE_BEV_20250605.png",
       "url": "images/2025-05/newzealand_legacy_ICE_BEV_20250605.png",
-      "alt": "Newzealand (Legacy) ICE-BEV-Hybrid trajectory",
+      "alt": "New Zealand (Legacy) ICE-BEV-Hybrid trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "share",
       "period": "2025-05",
       "date": "2025-06-05",
       "filename": "newzealand_legacy_20250605.png",
       "url": "images/2025-05/newzealand_legacy_20250605.png",
-      "alt": "Newzealand (Legacy) BEV trajectory",
+      "alt": "New Zealand (Legacy) BEV trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "time",
       "period": "2025-05",
       "date": "2025-06-05",
       "filename": "newzealand_legacy_time_20250605.png",
       "url": "images/2025-05/newzealand_legacy_time_20250605.png",
-      "alt": "Newzealand (Legacy) Transition time curve",
+      "alt": "New Zealand (Legacy) Transition time curve",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ttm_shares",
       "period": "2025-05",
       "date": "2025-06-05",
       "filename": "newzealand_legacy_ttm_shares_20250605.png",
       "url": "images/2025-05/newzealand_legacy_ttm_shares_20250605.png",
-      "alt": "Newzealand (Legacy) TTM market split graph",
+      "alt": "New Zealand (Legacy) TTM market split graph",
       "country_slug": "newzealand_legacy"
     },
     {
@@ -22262,43 +22262,43 @@
       "country_slug": "czechia"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ICE_BEV",
       "period": "2025-04",
       "date": "2025-05-31",
       "filename": "newzealand_legacy_ICE_BEV_20250531.png",
       "url": "images/2025-04/newzealand_legacy_ICE_BEV_20250531.png",
-      "alt": "Newzealand (Legacy) ICE-BEV-Hybrid trajectory",
+      "alt": "New Zealand (Legacy) ICE-BEV-Hybrid trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "share",
       "period": "2025-04",
       "date": "2025-05-31",
       "filename": "newzealand_legacy_20250531.png",
       "url": "images/2025-04/newzealand_legacy_20250531.png",
-      "alt": "Newzealand (Legacy) BEV trajectory",
+      "alt": "New Zealand (Legacy) BEV trajectory",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "time",
       "period": "2025-04",
       "date": "2025-05-31",
       "filename": "newzealand_legacy_time_20250531.png",
       "url": "images/2025-04/newzealand_legacy_time_20250531.png",
-      "alt": "Newzealand (Legacy) Transition time curve",
+      "alt": "New Zealand (Legacy) Transition time curve",
       "country_slug": "newzealand_legacy"
     },
     {
-      "country": "Newzealand (Legacy)",
+      "country": "New Zealand (Legacy)",
       "type": "ttm_shares",
       "period": "2025-04",
       "date": "2025-05-31",
       "filename": "newzealand_legacy_ttm_shares_20250531.png",
       "url": "images/2025-04/newzealand_legacy_ttm_shares_20250531.png",
-      "alt": "Newzealand (Legacy) TTM market split graph",
+      "alt": "New Zealand (Legacy) TTM market split graph",
       "country_slug": "newzealand_legacy"
     },
     {


### PR DESCRIPTION
## Summary
The manifest builder was splitting country slugs on the first underscore, so:

- \`south_korea_*.png\` → "South (Korea)"
- \`new_zealand_*.png\` → "New (Zealand)"
- legacy \`southkorea_*.png\` → "Southkorea"
- legacy \`newzealand_*.png\` → "Newzealand"

The country dropdown ended up with two or three duplicate entries per country, and the cards looked broken.

## Fix
\`label_from_slug()\` now matches the full slug against a known multi-word country list (\`south_korea\`, \`new_zealand\`, \`saudi_arabia\`, \`south_africa\`, \`hong_kong\`, \`czech_republic\`, \`united_kingdom\`, \`united_states\`) before falling back to the first-underscore split. Legacy single-word slugs (\`southkorea\`, \`newzealand\`, …) are mapped to the same display label so old PNGs and new PNGs collapse into one dropdown entry.

## Important: nothing on disk is renamed
- Existing image filenames stay as they are (\`southkorea_*.png\`, \`newzealand_legacy_*.png\`, …).
- Only the \`country\` field in \`manifest.json\` is unified after the next manifest rebuild.
- \`country_slug\` keeps the on-disk slug so URLs and downloads are untouched.

## After merge
The \`Build manifest\` workflow re-runs on the next image push or via \`workflow_dispatch\`, and the gallery will show one "South Korea" / "New Zealand" entry covering both legacy and current renders.

## Test plan
- [ ] Trigger \`build-manifest.yml\` after merge, confirm \`grep '"country":' manifest.json | sort -u\` no longer shows "Southkorea", "Newzealand", "New (Zealand)", "South (Korea)".
- [ ] Open the gallery, confirm the country dropdown has a single "South Korea" entry and that selecting it shows both legacy and new charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)