### PR TITLE
docs(architecture): document Workers Builds auto-deploy + consolidated cron schedule + Netherlands/China fetch flows

### DIFF
--- a/architecture/bev-gallery-architecture-brief.md
+++ b/architecture/bev-gallery-architecture-brief.md
@@ -82,10 +82,27 @@
 
 ### 3.5 GitHub Actions
 - **`Build manifest` (`.github/workflows/build-manifest.yml`):** Triggert auf Push zu `images/**` oder `build_manifest.R`. Installiert R, ruft `build_manifest.R`, committet `manifest.json`. Cron-Fallback täglich 03:17 UTC.
-- **`Render country charts` (`.github/workflows/render-country.yml`):** Manueller Trigger via Actions UI (`workflow_dispatch`) mit Inputs `country` und `variant`. Installiert R + Pakete (`renv`-Cache empfohlen), ruft `R/render_country.R`, committet `images/`+`params.csv`+`weights.csv`. Triggert dadurch implizit den Manifest-Build.
+- **`Render country charts` (`.github/workflows/render-country.yml`):** Manueller Trigger via Actions UI (`workflow_dispatch`) plus reusable `workflow_call`-Eintrittspunkt (genutzt von den Multi-Country-Fetchern wie ACEA). Inputs `country` und `variant`. Installiert R + Pakete, ruft `R/render_country.R`, committet `images/`+`params.csv`+`weights.csv`+`posts/`. Dispatcht im Erfolgsfall `build-manifest.yml` explizit.
+- **`Snapshot Builder curves` (`.github/workflows/snapshot-builder.yml`):** Cron 25. jedes Monats 09:00 UTC plus `workflow_dispatch`. Dumpt die aggregierten Builder-Kurven nach `builder_history/<date>.csv`.
+- **Country Fetch Actions (Familie `.github/workflows/fetch-*.yml`):** Ein Workflow pro Datenquelle. Cron-getrieben, self-throttling über `latest_period(<CSV>) ≥ target`. Nach Schreib-Diff Auto-Dispatch von `render-country.yml` pro betroffener Country/Variant. Aktueller Stand (Schedule in UTC):
+  - `fetch-acea.yml` — täglich 08:00, 16.→EOM. Bis zu 21 EU-Länder (16 always + 5 conditional).
+  - `fetch-brazil.yml` — monatlich 10. 08:00. Brazil.
+  - `fetch-chile.yml` — täglich 08:00, 14.→EOM. Chile.
+  - `fetch-china.yml` — täglich 11:00, 1.→EOM. China (retail + wholesale).
+  - `fetch-japan.yml` — täglich 08:00, 1.→EOM. Japan.
+  - `fetch-netherlands.yml` — täglich 06:30, 1.→15. Netherlands (Whole / Used / HDV).
+  - `fetch-turkey.yml` — täglich 08:00, 15.→EOM. Türkiye (benötigt manuelles `press_id`).
+  - `fetch-uruguay.yml` — täglich 08:00, 1.→EOM. Uruguay.
+  - `fetch-usa.yml` — täglich 10:00, 10.→EOM. USA (trailing 3-month window).
 
 ### 3.6 GitHub Pages
 - **Rolle:** Static Hosting für die Gallery. Auto-Deploy auf jeden Push zu `master`.
+
+### 3.7 Cloudflare Workers Builds — Auto-Deploy-Pipeline für den Worker
+- **Rolle:** Cloudflare-seitige CI/CD-Integration, die `worker/index.js` + `worker/wrangler.toml` bei jedem Push zu `master` automatisch deployt. Ersetzt den vorherigen rein-lokalen `wrangler deploy`-Pfad als Default; der lokale CLI-Pfad bleibt Fallback.
+- **Konfiguration:** Cloudflare Dashboard → Workers → `leraffl-gallery-feedback` → Settings → Builds → "Connect to Git". Root directory `worker`, Deploy command `npx wrangler deploy`, Branch `master`.
+- **Was deployt wird:** Code + `wrangler.toml`. **Secrets nicht.** Der `GITHUB_TOKEN` lebt weiterhin nur in der Worker-Runtime-Env und wird out-of-band rotiert.
+- **Trust-Implikation:** Cloudflare hat ab jetzt Read-Access auf den GitHub-Repo via OAuth-App `Cloudflare Workers & Pages`. Scope ist auf das Repo begrenzt; kein Schreibzugriff. Im Disaster-Fall (revoked Integration) bleibt der Worker auf der letzten deployten Version und der manuelle `wrangler`-Pfad funktioniert weiter.
 
 ---
 
@@ -169,7 +186,8 @@
 | Layer | Technologie | Wo verwendet |
 |---|---|---|
 | Runtime: Edge | Cloudflare Workers (V8 isolate) | Worker `/issues` und `/submissions` |
-| Runtime: CI | GitHub Actions (Ubuntu Runner) | Manifest-Build, Country-Render |
+| Runtime: CI | GitHub Actions (Ubuntu Runner) | Manifest-Build, Country-Render, Country-Fetcher (9 Workflows), Snapshot-Builder |
+| Runtime: CI (extern) | Cloudflare Workers Builds | Auto-Deploy `worker/` bei Push zu `master` |
 | Runtime: Static Hosting | GitHub Pages | Gallery |
 | Sprache: Backend | JavaScript (ES Modules, Workers API) | Worker |
 | Sprache: Frontend | Vanilla JS (ES2020), HTML5, CSS3 (kein Build) | `index.html` |
@@ -189,7 +207,8 @@
 |---|---|---|---|
 | GitHub (Repo, Issues, PRs, Actions, Pages) | Source-of-Truth, CI/CD, Hosting, Diskussionsplattform | GitHub Inc. | hoch — Single Point of Failure für nahezu alles |
 | Cloudflare (Workers, KV, OAuth) | Edge-Compute, Anti-Abuse | Cloudflare Inc. | hoch — ohne Worker keine Submit/Feedback-Funktionalität |
-| Cloudflare Dashboard | Out-of-band Worker-Konfiguration (compatibility_date, observability, logs) | Maintainer | medium — Einstellungen werden in `wrangler.toml` gespiegelt |
+| Cloudflare Dashboard | Out-of-band Worker-Konfiguration (compatibility_date, observability, logs) **plus Workers-Builds-Konfiguration (Branch, Root directory, Deploy command, GitHub-OAuth-Verknüpfung)** | Maintainer | medium — Einstellungen werden in `wrangler.toml` gespiegelt; die Git-Integration ist OAuth-basiert und revoke-bar |
+| Cloudflare ↔ GitHub OAuth-App | Read-Access auf das Repo für Workers Builds (Code-Checkout zum Bauen). Kein Schreibzugriff. | Maintainer (granted), Cloudflare Inc. (Konsument) | medium — Revoke macht Auto-Deploy unmöglich, ohne den Worker selbst zu beeinflussen; lokaler `wrangler` bleibt nutzbar |
 | Posit Public Package Manager | R-Package-Quelle in CI | Posit | medium — Cache-fähig |
 | Google Sheets | Legacy: Rohdaten-Quelle für Maintainer-lokalen R-Run | Maintainer | sinkt — wird durch `data/<Country>.csv` ersetzt |
 | ACEA (acea.auto) | Zukünftige primäre Multi-Land-Quelle (geplant) | ACEA | extern, wird gescraped |

--- a/docs/architecture/02-components.md
+++ b/docs/architecture/02-components.md
@@ -107,6 +107,10 @@ Full contracts → [04-interfaces.md](04-interfaces.md).
 - `RATE_KV` (binding) — Cloudflare KV namespace used as a per-IP counter with 1-hour TTL
 - `GITHUB_OWNER`, `GITHUB_REPO` (vars) — non-secret config
 
+### How it gets deployed
+
+The Worker is linked to this repository via **Cloudflare Workers Builds** (configured in the Cloudflare dashboard → Workers → `leraffl-gallery-feedback` → Settings → Builds). Any push to `master` that touches `worker/` triggers `npx wrangler deploy` from the `worker/` subdirectory inside a Cloudflare-managed build container. No local CLI step needed for routine deploys; `wrangler` from the maintainer's Mac is the manual fallback. Secrets (`GITHUB_TOKEN`) live in the Worker's runtime env and are not read from the repo. Full deploy runbook in [08-deploy-ops.md § 8.1](08-deploy-ops.md#81-deploy-the-worker).
+
 ### Why a Worker and not Lambdas / Vercel functions / a tiny VPS?
 
 - Cloudflare Workers free tier covers our load comfortably (we'd need >100k requests/day to leave it)
@@ -227,7 +231,29 @@ Defensive — if a manual upload bypasses the Render action (legacy local R work
 
 ---
 
-## 2.7 GitHub Pages
+## 2.7 Fetch Actions (overview)
+
+A family of country-specific `fetch-<source>.yml` workflows that scrape national registration sources, upsert the new monthly row into the relevant `data/<Country>.csv`, and dispatch `render-country.yml` per touched country/variant when a CSV actually changed. Each follows the same shape (`workflow_dispatch` + `schedule`, Python script under `scripts/fetch_<source>.py`, EndBug commit, then `gh workflow run render-country.yml`) but the parser is intentionally country-local — every statistics agency has its own URL scheme, file layout, and quirks that don't justify a generic abstraction.
+
+| Workflow | Source | Variants written | Scope | Schedule |
+|---|---|---|---|---|
+| [`fetch-acea.yml`](../../.github/workflows/fetch-acea.yml) | ACEA monthly PDF press release | `Whole` only | Up to 21 EU countries (16 always + 5 conditional, see [Flow K](05-flows.md#flow-k--acea-ingest)) | Daily 08:00 UTC, 16th → EOM |
+| [`fetch-brazil.yml`](../../.github/workflows/fetch-brazil.yml) | ANFAVEA Excel | `Whole` | Brazil | Monthly 10th 08:00 UTC |
+| [`fetch-chile.yml`](../../.github/workflows/fetch-chile.yml) | ANAC (Mercado + Cero y Bajas Emisiones) | `Whole` | Chile | Daily 08:00 UTC, 14th → EOM |
+| [`fetch-china.yml`](../../.github/workflows/fetch-china.yml) | CPCA monthly market analysis | `Whole` (retail) + `Wholesale` to separate CSV | China | Daily 11:00 UTC, 1st → EOM |
+| [`fetch-japan.yml`](../../.github/workflows/fetch-japan.yml) | JADA (XLSX preferred, PDF fallback) | `Whole` | Japan | Daily 08:00 UTC, 1st → EOM |
+| [`fetch-netherlands.yml`](../../.github/workflows/fetch-netherlands.yml) | RDW via Swing BI (`duurzamemobiliteit.databank.nl`) | `Whole` + `Used` + `HDV` | Netherlands | Daily 06:30 UTC, 1st → 15th |
+| [`fetch-turkey.yml`](../../.github/workflows/fetch-turkey.yml) | TÜİK press bulletin (PDF + OCR) | `Whole` | Türkiye | Daily 08:00 UTC, 15th → EOM (requires manual `press_id`) |
+| [`fetch-uruguay.yml`](../../.github/workflows/fetch-uruguay.yml) | ACAU "Compilado YYYY" xlsx | `Whole` (AUTOS + SUV aggregated) | Uruguay | Daily 08:00 UTC, 1st → EOM |
+| [`fetch-usa.yml`](../../.github/workflows/fetch-usa.yml) | ANL Total Sales PDF | `Whole` (trailing 3-month window) | USA | Daily 10:00 UTC, 10th → EOM |
+
+Countries with a `data/<Country>.csv` but **no** auto-fetcher rely on the legacy local R pipeline (§ 2.10) or on public-submit PRs: Australia, Austria, Canada, Denmark, Finland, Georgia, Germany, Indonesia, Ireland, Italy, New Zealand, Portugal, Singapore, South Korea, Sweden, Thailand, UK. Same for ACEA's conditional-list countries (Luxembourg, Norway, Poland, Spain, Switzerland) until their existing source flips to pure `ACEA`.
+
+Per-flow design notes, sequence diagrams, and validation tables live in [05-flows.md](05-flows.md) (Flows H–P). Cron schedules in one place: [08-deploy-ops.md § 8.11](08-deploy-ops.md#811-cron-schedule-overview).
+
+---
+
+## 2.8 GitHub Pages
 
 ### What it is
 
@@ -249,7 +275,7 @@ GitHub Pages serves with default `Cache-Control: max-age=600`. The page uses `ca
 
 ---
 
-## 2.8 Builder Snapshot Script (`scripts/snapshot_builder.py`)
+## 2.9 Builder Snapshot Script (`scripts/snapshot_builder.py`)
 
 ### What it is
 
@@ -276,7 +302,7 @@ The render pipeline produces per-country PNGs and updates `params.csv` / `weight
 
 ---
 
-## 2.9 Snapshot-Builder Action (`.github/workflows/snapshot-builder.yml`)
+## 2.10 Snapshot-Builder Action (`.github/workflows/snapshot-builder.yml`)
 
 ### What it is
 
@@ -293,7 +319,7 @@ Most country fetchers (Brazil, Chile, Japan, ACEA) run during the first half of 
 
 ---
 
-## 2.10 Legacy Local R Pipeline
+## 2.11 Legacy Local R Pipeline
 
 ### What it is
 

--- a/docs/architecture/05-flows.md
+++ b/docs/architecture/05-flows.md
@@ -18,9 +18,11 @@ End-to-end sequence diagrams for every meaningful user journey or background pro
 | J | [Auto-ingest Japan from JADA](#flow-j--jada-ingest) | Daily cron (1st–end of month, 08:00 UTC) or manual dispatch | Updated `data/Japan.csv` → triggers Flow B for Japan |
 | K | [Auto-ingest multi-country from ACEA](#flow-k--acea-ingest) | Daily cron (16th–end of month, 08:00 UTC) or manual dispatch | Updated `data/<Country>.csv` for ≤21 countries → sequential Flow B for each |
 | L | [Snapshot Builder curves](#flow-l--snapshot-builder) | Monthly cron (25th, 09:00 UTC) or manual dispatch | New `builder_history/<date>.csv` + updated `index.json` |
-| L | [Auto-ingest Uruguay from ACAU](#flow-l--acau-ingest) | Daily cron (1st–end of month, 08:00 UTC) or manual dispatch | Updated `data/Uruguay.csv` → triggers Flow B for Uruguay |
+| L₂ | [Auto-ingest Uruguay from ACAU](#flow-l--acau-ingest) | Daily cron (1st–end of month, 08:00 UTC) or manual dispatch | Updated `data/Uruguay.csv` → triggers Flow B for Uruguay |
 | M | [Auto-ingest Türkiye from TÜİK](#flow-m--tuik-ingest) | Daily cron (15th–end of month, 08:00 UTC) or manual dispatch with `press_id` | Updated `data/Türkiye.csv` → triggers Flow B for Türkiye |
 | N | [Auto-ingest USA from ANL](#flow-n--anl-ingest) | Daily cron (10th–end of month, 10:00 UTC) or manual dispatch | Updated `data/USA.csv` (trailing 3-month window) → triggers Flow B for USA |
+| O | [Auto-ingest Netherlands from RDW/Swing](#flow-o--rdw-swing-ingest) | Daily cron (1st–15th, 06:30 UTC) or manual dispatch | Updated `data/Netherlands.csv` / `Netherlands_Used.csv` / `Netherlands_HDV.csv` → per-variant Flow B |
+| P | [Auto-ingest China from CPCA](#flow-p--cpca-ingest) | Daily cron (1st–end of month, 11:00 UTC) or manual dispatch | Updated `data/China.csv` (+ `China_Wholesale.csv`) → triggers Flow B for China |
 
 ---
 
@@ -585,9 +587,6 @@ The PDF's column layout (BEV, PHEV, HEV, OTHERS, PETROL, DIESEL, TOTAL) has been
 ## Flow L — Snapshot Builder
 
 The Builder tab's aggregated curves (BEV / ICE / PHEV per group, weighted by `weights.csv`) are entirely derived from `params.csv` + `weights.csv`. To enable a future time-lapse of how the global bottom-up curve evolves, we periodically dump the curve to disk so each snapshot is a frozen, append-only artefact independent of future parameter changes.
-## Flow L — ACAU ingest
-
-Uruguay follows the same `fetch-<country>` shape as Brazil / Japan / Chile. ACAU publishes one yearly "Compilado YYYY" xlsx (per-model rows, six sheets — AUTOS, SUV, MINIBUSES, UTILITARIO, CAMIONES, OMNIBUS) that gets edited in place with each new month's volumes. We aggregate AUTOS + SUV into a single passenger-car series. The cron runs daily from the 1st onward and the script self-throttles via the CSV's latest period — most invocations are a no-op until ACAU edits the previous month into the file (typically the first week of the following month, but with no published embargo date).
 
 ```mermaid
 sequenceDiagram
@@ -615,6 +614,14 @@ sequenceDiagram
 **Why bit-equivalent to the in-page Builder:** the static page is the canonical surface area for the curves. Anyone comparing a snapshot to the live page (e.g. validating a time-lapse frame against today's view) should see identical numbers. The cross-check is mechanical: a Node port of `bevShareIndex` / `getT0Years` / `baselineYearOf` over the same `params.csv` matches the Python script to four decimal places.
 
 **Why no render re-trigger:** snapshots are downstream of `params.csv` — they don't feed back into any chart, post-text, or manifest. The workflow only commits the new file; the page is not yet a consumer.
+
+## Flow L₂ — ACAU ingest
+
+Uruguay follows the same `fetch-<country>` shape as Brazil / Japan / Chile. ACAU publishes one yearly "Compilado YYYY" xlsx (per-model rows, six sheets — AUTOS, SUV, MINIBUSES, UTILITARIO, CAMIONES, OMNIBUS) that gets edited in place with each new month's volumes. We aggregate AUTOS + SUV into a single passenger-car series. The cron runs daily from the 1st onward and the script self-throttles via the CSV's latest period — most invocations are a no-op until ACAU edits the previous month into the file (typically the first week of the following month, but with no published embargo date).
+
+```mermaid
+sequenceDiagram
+    participant Cron as GitHub Actions (cron / dispatch)
     participant Job as fetch-uruguay.yml job
     participant Site as acau.com.uy
     participant CSV as data/Uruguay.csv
@@ -902,6 +909,119 @@ months — this is the point the maintainer flagged up front).
 The sample PDF (`data/Total Sales for Website_April 2026.pdf`) is in `master`
 (committed by the maintainer as "Add files via upload"), not produced by the
 branch.
+
+## Flow O — RDW/Swing ingest
+
+Netherlands is the first country with **three variants in one workflow** (Whole / Used Imports / HDV). Source is `duurzamemobiliteit.databank.nl`, a Swing 7.1 BI portal (ABF Research) that exposes RDW registration data. There is no documented public API; we drive three pre-saved Swing workspace permalinks the maintainer configured in the UI (one per variant). Each variant writes to its own CSV and triggers `render-country.yml` independently if it changed.
+
+```mermaid
+sequenceDiagram
+    participant Cron as GitHub Actions (cron / dispatch)
+    participant Job as fetch-netherlands.yml job
+    participant Swing as duurzamemobiliteit.databank.nl
+    participant CSVs as data/Netherlands{,_Used,_HDV}.csv
+    participant Render as render-country.yml
+
+    Cron->>Job: workflow_dispatch OR cron (daily 1–15, 06:30 UTC)
+    loop per variant in {Whole, Used, HDV}
+        Job->>Swing: GET /viewer?workspace_guid=<TEMPLATE>
+        Swing-->>Job: HTML with WsGuid: "<session>"
+        Job->>Swing: POST /viewer/Presentation/GetTableStart (session GUID)
+        opt pivot longer than initial page
+            Job->>Swing: POST /viewer/Presentation/GetTableRows
+        end
+        Swing-->>Job: pivot rows (HTML fragments)
+        Job->>Job: Detect orientation (periods-in-rows vs fuels-in-rows)
+        Job->>Job: Parse Dutch labels → BEV/PHEV/PETROL/DIESEL/OTHERS<br/>(Benzine→PETROL, FCEV+Overig→OTHERS, HEV blank)
+        Job->>Job: Decode Dutch locale ("6.863"=6863, "&nbsp;"=0)
+        Job->>CSVs: Upsert into per-variant file
+    end
+    Job->>Job: git diff each CSV → touched=[variants that changed]
+    alt any touched
+        Job->>CSVs: Single commit for the touched files
+        loop per touched variant
+            Job->>Render: gh workflow run render-country.yml -f country=Netherlands -f variant=<v>
+        end
+    else nothing touched
+        Job-->>Cron: Exit cleanly (no-op, no commit)
+    end
+```
+
+**Where parsing lives:** [scripts/fetch_netherlands.py](../../scripts/fetch_netherlands.py). Pipeline rationale, variant choices, template-GUID maintenance, and HEV/FCEV fold-in convention live in [10-source-netherlands.md](10-source-netherlands.md) — read that before changing the `TEMPLATES` constant.
+
+**Vehicle scope:** Personenauto (passenger cars) for Whole + Used; Zware bedrijfsvoertuigen (heavy commercial > 3.5 t) for HDV. See [09-glossary.md § Vehicle scope per source](09-glossary.md#vehicle-scope-per-source).
+
+**Why three variants in one workflow:** all three pivots ride on the same Swing session protocol, the same response shape, and the same fuel-label map. Splitting them into three workflows would triple the YAML for zero functional gain. Per-variant render dispatch lets a single-variant change still trigger only the right re-render.
+
+**Why HEV is always blank:** RDW source data does not split full hybrids from PETROL/DIESEL — full hybrids fold into Benzine or Diesel upstream in the agency's classification. We leave the `HEV` column empty rather than guess; the page treats blank as "category unsupported for this country" rather than zero.
+
+**Why a separate `Used Imports` variant:** the Dutch market includes a sizeable parallel-import stream (used cars imported from Germany/Belgium and re-registered). RDW publishes this as its own dimension; we surface it so the maintainer can compare the new-registration trajectory against the used-import trajectory in the gallery's variant picker.
+
+**Why daily 1st–15th at 06:30 UTC:** RDW publishes the previous month sometime in the first half of the following month — exact day varies. We poll daily and the script self-throttles once the previous month's row exists in all three CSVs (no diff, no commit, no render trigger). 06:30 UTC sits clear of the 08:00 UTC slot used by Brazil/Chile/Japan/Türkiye/Uruguay/ACEA and most country-side timezones.
+
+**Why Swing-permalinks instead of a documented API:** Swing 7.1 exposes only undocumented endpoints (`GetTableStart`, `GetTableRows`) that require a session GUID bootstrapped from the HTML response of the workspace permalink. Reverse-engineering and replaying this is the only path; the alternative is a once-a-month manual CSV download, which contradicts the project's automation goal.
+
+**Known fragility:** the `TEMPLATES` constant in `scripts/fetch_netherlands.py` carries three Swing workspace GUIDs. If ABF/RDW rebuild the BI portal or invalidate saved workspaces, these GUIDs break. Recovery is a Swing-UI session: pick the source/dimension/period, share-icon → permalink, copy the new GUID into the script. See [10-source-netherlands.md § "If the GUIDs break"](10-source-netherlands.md) for the step-by-step.
+
+## Flow P — CPCA ingest
+
+China follows the same `fetch-<country>` pattern as Brazil/Chile/Japan/Uruguay/Türkiye, but with three structural twists: (1) CPCA reports both retail (零售) and wholesale (批发) in the same article, so the parser writes **two CSVs in one run** (`data/China.csv` for retail, `data/China_Wholesale.csv` for wholesale-only downstream model); (2) the retail-side BEV/PHEV/EREV breakdown is not in the article text — it's only on an embedded NEV-market slide JPG, so the parser shells out to `tesseract-ocr` for the retail split; (3) CPCA restates the previous month inside each new release, so the parser overwrites existing periods when their values move.
+
+```mermaid
+sequenceDiagram
+    participant Cron as GitHub Actions (cron / dispatch)
+    participant Job as fetch-china.yml job
+    participant CPCA as cpcaauto.com
+    participant Retail as data/China.csv
+    participant Whole as data/China_Wholesale.csv
+    participant Render as render-country.yml
+
+    Cron->>Job: workflow_dispatch OR cron (daily 1–31, 11:00 UTC)
+    Job->>Retail: read latest period
+    Job->>Whole: read latest period
+    alt Both CSVs already at target month AND no --force
+        Job-->>Cron: Exit cleanly (no-op)
+    else Target month missing
+        alt --url / --id supplied
+            Job->>CPCA: GET /newslist.php?types=csjd&id=<id>
+        else
+            Job->>CPCA: GET /news.php?types=csjd&anid=129&nid=24 (listing)
+            CPCA-->>Job: HTML listing
+            Job->>Job: Find link "【月度分析】<year>年<month>月份…"
+            Job->>CPCA: GET resolved detail URL
+        end
+        CPCA-->>Job: detail-page HTML
+        Job->>Job: Parse retail narrative (零售 / 新能源…零售 / 常规燃油…零售) → TOTAL, NEV-agg, ICE
+        Job->>Job: Parse wholesale narrative (批发 / 纯电动 / 狭义插混 / 增程式 / 常规燃油…批发) → TOTAL, BEV, PHEV, EREV, ICE
+        Job->>CPCA: GET embedded NEV-market slide JPG
+        CPCA-->>Job: image bytes
+        Job->>Job: tesseract-ocr → retail BEV/PHEV/EREV split
+        Job->>Job: Sanity: BEV+PHEV+EREV ≈ NEV-aggregate from narrative
+        Job->>Retail: Upsert target period (retail row)
+        Job->>Whole: Upsert target period (wholesale row)
+        Job->>Job: git diff each CSV → touched=[variants that changed]
+        Job->>Retail: Commit touched files in one commit
+        opt Whole variant in touched
+            Job->>Render: gh workflow run render-country.yml -f country=China -f variant=Whole
+        end
+    end
+```
+
+**Where parsing lives:** [scripts/fetch_china.py](../../scripts/fetch_china.py). The module docstring documents the two-track model (retail vs wholesale), the OCR slide pipeline, the `万辆 → unit` conversion (1 万 = 10,000), and the EREV→PHEV-fold convention used by `data/China.csv` (retail PHEV column carries narrow-PHEV + EREV combined).
+
+**Vehicle scope:** Passenger cars (乘用车) only. Commercial vehicles, kei-equivalent NEVs, and exports are out of scope. See [09-glossary.md § Vehicle scope per source](09-glossary.md#vehicle-scope-per-source).
+
+**Why retail + wholesale into two CSVs:** the existing `data/China.csv` has tracked retail since 2020; the wholesale series is a separate downstream model the maintainer wants kept distinct rather than blended. Two CSVs in one fetcher keeps the parsing pass single (one HTML fetch, one detail page) while preserving the schema separation.
+
+**Why only retail (Whole) triggers a render:** the gallery's per-country pipeline is wired to `data/<Country>.csv`; `data/China_Wholesale.csv` is consumed by a separate offline model and isn't surfaced in the page yet. Dispatching `render-country.yml` for Wholesale would produce nothing useful today.
+
+**Why OCR for the retail split:** CPCA publishes the article narrative with only an NEV-aggregate retail figure ("新能源乘用车市场零售 Y万辆"). The per-fuel BEV/PHEV/EREV breakdown for retail sits inside an embedded JPG (their NEV market-overview slide). pypdf-style extractors return nothing for raster content; tesseract on the slide is the only path to the per-fuel retail row without manual transcription. The eng language pack suffices — table data is Latin digits.
+
+**Why daily from the 1st at 11:00 UTC:** CPCA's monthly analysis lands between the 8th and 11th of the following month (e.g. March 2026 was published 2026-04-09, April 2026 on 2026-05-09). Cron starts day 1 and the self-throttle makes empty days free. 11:00 UTC = 19:00 Beijing — well after CPCA's typical mid-morning publication slot — and clears the 08:00 UTC slot already crowded by Brazil/Chile/Japan/Türkiye/Uruguay/ACEA.
+
+**Why overwrites for existing periods:** unlike Brazil/Chile/Japan (which never touch older rows once written), CPCA restates the prior month inside each new release. The parser writes any target period unconditionally; the change-detection step still ensures no-op runs don't commit.
+
+**Known limitation:** auto-discovery falls back to a listing scrape (`news.php?types=csjd&anid=129&nid=24`) — if CPCA changes that page layout, the workflow inputs `detail_id` and `detail_url` are the manual override. The numeric `id` is visible in the detail-page URL once the maintainer opens the article in a browser.
 
 ## See also
 

--- a/docs/architecture/06-tech-stack.md
+++ b/docs/architecture/06-tech-stack.md
@@ -95,6 +95,7 @@ id      = "<redacted>"
 |---|---|---|
 | GitHub | Free public repo | Source, Issues, PRs, Actions, Pages |
 | Cloudflare Workers | Free | The edge worker |
+| Cloudflare Workers Builds | Free | Auto-deploys the worker on every push to `master` that touches `worker/` — `npx wrangler deploy` runs in a Cloudflare-managed build container, no local CLI needed. Configured per-Worker in the dashboard (Settings → Builds → Connect to Git). |
 | Cloudflare KV | Free (under 1k writes/day, 100k reads/day) | Rate-limit counters |
 | Posit Public Package Manager | Free | R package binaries for CI |
 

--- a/docs/architecture/08-deploy-ops.md
+++ b/docs/architecture/08-deploy-ops.md
@@ -6,23 +6,41 @@ Operational runbook. How to deploy, how to trigger, how to debug. Commands you c
 
 | Task | Command | Section |
 |---|---|---|
-| Deploy worker code change | `cd worker && npx wrangler@latest deploy` | [§ 8.1](#81-deploy-the-worker) |
+| Deploy worker code change | Push to `master` (Workers Builds auto-deploys); fallback `cd worker && npx wrangler@latest deploy` | [§ 8.1](#81-deploy-the-worker) |
 | Re-render one country | Actions tab → "Render country charts" → Run workflow | [§ 8.2](#82-trigger-a-country-render) |
 | Add a new country | Extract CSV, push, run render | [§ 8.3](#83-add-a-new-country) |
-| Rotate the Worker's PAT | Edit PAT in GitHub, re-`wrangler secret put` | [§ 8.4](#84-rotate-secrets) |
+| Rotate the Worker's PAT | Edit PAT in GitHub, re-`wrangler secret put` (or re-set in Workers Builds env) | [§ 8.4](#84-rotate-secrets) |
 | Merge a public submission | Review PR diff, click Merge, then [§ 8.2](#82-trigger-a-country-render) | [§ 8.5](#85-process-a-submission-pr) |
 | Hide spam feedback | Add `hidden` label to the issue | [§ 8.6](#86-moderate-feedback) |
 | Bulk-render all countries | Loop through countries calling [§ 8.2](#82-trigger-a-country-render) one at a time | [§ 8.7](#87-bulk-rerender) |
 | Debug Worker errors | Cloudflare dashboard → Workers → Tail logs | [§ 8.8](#88-debugging) |
 | Indonesia table shows ~5y 20→80 again | Frontend + backend recovery both already in place — see § "Indonesia v1=0 corruption" | [§ 8.8](#indonesia-v10-corruption) |
 | Manually snapshot Builder curves | Actions tab → "Snapshot Builder curves" → Run workflow | [§ 8.9](#89-snapshot-builder-curves) |
+| Look up when a country fetcher next runs | Cron schedule overview | [§ 8.11](#811-cron-schedule-overview) |
 
 ## 8.1 Deploy the Worker
+
+### Default path — Workers Builds (auto-deploy from Git)
+
+The Cloudflare Worker is linked to this repository via **Workers Builds** (Cloudflare → Workers → `leraffl-gallery-feedback` → Settings → Builds → "Connect to Git"). Any push to `master` that touches the `worker/` subdirectory triggers a Cloudflare build that runs `npx wrangler deploy` from the repo root (build config: `Root directory = worker`, `Deploy command = npx wrangler deploy`, `Branch = master`). No local CLI step needed for the day-to-day case.
 
 Required when **any** of these change:
 - `worker/index.js`
 - `worker/wrangler.toml` (compat date, KV bindings, account_id, vars)
-- The Worker's `GITHUB_TOKEN` secret (set separately, see § 8.4)
+
+**What you should see** in Cloudflare dashboard → Workers & Pages → `leraffl-gallery-feedback` → Builds:
+- A "Building" row appears within ~30 s of the push
+- Logs show `npx wrangler deploy` running, KV/var bindings being read, upload + deploy completing in ~10–15 s
+- Final state: `Success`, with the deployed version pinned to the commit SHA
+
+If the build fails:
+- **Auth-side**: re-link the GitHub integration (the dashboard surfaces a "Reconnect" button); see the [Cloudflare Workers Builds docs](https://developers.cloudflare.com/workers/ci-cd/builds/) for the OAuth flow.
+- **Build-side**: same diagnostics as a local `wrangler deploy` failure (compat date, KV binding name mismatch, missing secret).
+- **Fallback**: deploy manually from the maintainer's Mac with the command below — Workers Builds is convenience, not load-bearing.
+
+### Fallback path — manual deploy from the maintainer's Mac
+
+Still required if Workers Builds is unavailable (CI outage, GitHub integration revoked, hotfix-out-of-band):
 
 ```bash
 cd /Users/leraffl/Projects/GitHub/LeRaffl-Gallery/worker
@@ -42,6 +60,8 @@ Deployed leraffl-gallery-feedback triggers (~5 sec)
 ```
 
 If wrangler prompts about a config diff between local and remote, **say no** and reconcile the diff first (usually means someone tweaked the worker via the Cloudflare dashboard; pull those settings into `wrangler.toml`).
+
+> **Secrets are not auto-deployed.** Workers Builds only ships the code + `wrangler.toml`. The `GITHUB_TOKEN` secret lives in the Worker's runtime environment (set out-of-band via `wrangler secret put` or the dashboard) and is **not** read from the repository. See § 8.4 to rotate.
 
 ## 8.2 Trigger a country render
 
@@ -254,14 +274,62 @@ The script is zero-dependency (stdlib only) so no `pip install` is needed.
 
 ---
 
+## 8.11 Cron schedule overview
+
+Every scheduled GitHub Action in the repo, in one place. All times are UTC (GitHub Actions crons don't honour timezones). All schedules are best-effort — GitHub may delay cron runs by 5–15 minutes under load — and every workflow also exposes a `workflow_dispatch` trigger for manual runs from the Actions UI.
+
+### Country data-fetch actions
+
+These are the workflows that pull the previous month's data from each national source and commit the resulting CSV change. Each one self-throttles by re-reading the latest period from the target CSV before any HTTP work, so most invocations on empty days are free (no commit, no render trigger, no downstream fan-out).
+
+| Workflow | Cron expression | Human reading | Source | Country/Variant scope | Self-throttle |
+|---|---|---|---|---|---|
+| [`fetch-acea.yml`](../../.github/workflows/fetch-acea.yml) | `0 8 16-31 * *` | Daily 08:00 UTC, 16th → EOM | ACEA monthly PDF | Always-list (16): Belgium, Bulgaria, Croatia, Cyprus, Czechia, Estonia, France, Greece, Hungary, Iceland, Latvia, Lithuania, Malta, Romania, Slovakia, Slovenia. Conditional-list (5): Luxembourg, Norway, Poland, Spain, Switzerland — written only if existing source is exactly `ACEA`. | `max(period)` across always-list ≥ target |
+| [`fetch-brazil.yml`](../../.github/workflows/fetch-brazil.yml) | `0 8 10 * *` | Monthly 10th 08:00 UTC | ANFAVEA Excel | Brazil | (always fetches; idempotent on no-change) |
+| [`fetch-chile.yml`](../../.github/workflows/fetch-chile.yml) | `0 8 14-31 * *` | Daily 08:00 UTC, 14th → EOM | ANAC (two PDFs) | Chile | `latest_period(Chile.csv) ≥ target` |
+| [`fetch-china.yml`](../../.github/workflows/fetch-china.yml) | `0 11 1-31 * *` | Daily 11:00 UTC, 1st → EOM | CPCA monthly market analysis | China (retail → `China.csv`, wholesale → `China_Wholesale.csv`) | `latest_period` of both CSVs ≥ target |
+| [`fetch-japan.yml`](../../.github/workflows/fetch-japan.yml) | `0 8 1-31 * *` | Daily 08:00 UTC, 1st → EOM | JADA (XLSX preferred, PDF fallback) | Japan | `latest_period(Japan.csv) ≥ target` |
+| [`fetch-netherlands.yml`](../../.github/workflows/fetch-netherlands.yml) | `30 6 1-15 * *` | Daily 06:30 UTC, 1st → 15th | RDW via Swing BI (`duurzamemobiliteit.databank.nl`) | Netherlands — three variants: Whole, Used Imports, HDV | Per-variant diff vs CSV (no commit if all three idempotent) |
+| [`fetch-turkey.yml`](../../.github/workflows/fetch-turkey.yml) | `0 8 15-31 * *` | Daily 08:00 UTC, 15th → EOM | TÜİK press bulletin PDF + OCR | Türkiye | `latest_period(Türkiye.csv) ≥ target` — and requires manual `press_id` dispatch (no auto-discovery on SPA) |
+| [`fetch-uruguay.yml`](../../.github/workflows/fetch-uruguay.yml) | `0 8 1-31 * *` | Daily 08:00 UTC, 1st → EOM | ACAU "Compilado YYYY" xlsx | Uruguay (AUTOS + SUV aggregated) | `latest_period(Uruguay.csv) ≥ target` |
+| [`fetch-usa.yml`](../../.github/workflows/fetch-usa.yml) | `0 10 10-31 * *` | Daily 10:00 UTC, 10th → EOM | ANL Total Sales PDF | USA — trailing 3-month window (re-writes last 3 months on every run to absorb ANL revisions) | Change-detection on the 3-month window (no diff → no commit) |
+
+Notes on the schedule shape:
+- **08:00 UTC is the most crowded slot.** Brazil/Chile/Japan/Türkiye/Uruguay/ACEA all share it on the days they're scheduled. They don't conflict (each writes a different CSV; ACEA's matrix render fan-out is serialised by `max-parallel: 1`), but a CI outage at 08:00 UTC affects all of them simultaneously.
+- **Netherlands sits at 06:30 UTC** to clear the 08:00 crowd; **China at 11:00 UTC** to clear it from the other side; **USA at 10:00 UTC** to avoid piling onto the 10th's Brazil window.
+- **Day-1 starters** (Japan, Uruguay, China, Netherlands) rely entirely on the self-throttle to keep the empty days free — they fire 1-15 or 1-31 times per month but only do real HTTP on the days the source publishes.
+- **Date-window starters** (USA 10+, Chile 14+, Türkiye 15+, Netherlands ≤15, ACEA 16+) reflect the earliest plausible publication day for the previous month from that source; cutting off the empty days saves a handful of self-throttle checks but doesn't change correctness.
+
+Country coverage of automated fetchers: **see also** [02-components.md](02-components.md#27-fetch-actions-overview) for which CSVs are auto-fed vs hand-maintained. Countries without an entry in the table above (Australia, Austria, Canada, Denmark, Finland, Georgia, Germany, Indonesia, Ireland, Italy, New Zealand, Portugal, Singapore, South Korea, Sweden, Thailand, UK — and all conditional-list ACEA countries until their source flips to pure `ACEA`) are maintained manually via the legacy local R pipeline or via public-submit PRs.
+
+### Infrastructure actions
+
+| Workflow | Cron expression | Human reading | Purpose |
+|---|---|---|---|
+| [`build-manifest.yml`](../../.github/workflows/build-manifest.yml) | `17 3 * * *` | Daily 03:17 UTC | Self-healing fallback: rescans `images/` and rewrites `manifest.json` if anything drifted (also triggered on every push to `images/**` and on explicit dispatch from `render-country.yml`). |
+| [`snapshot-builder.yml`](../../.github/workflows/snapshot-builder.yml) | `0 9 25 * *` | Monthly 25th 09:00 UTC | Dumps the aggregated Builder curves into `builder_history/<date>.csv` for time-lapse purposes. The 25th sits after the bulk of in-month country fetches has settled (Brazil 10th, USA 10+, ACEA 16+, ANAC/Türkiye 14–18, JADA varies) and before the next month's fetches start. |
+| [`render-country.yml`](../../.github/workflows/render-country.yml) | (no cron) | On `workflow_dispatch` or `workflow_call` only | Manual or fan-out trigger from a fetch workflow — never auto-runs on its own clock. |
+
+### Reading a cron expression quickly
+
+GitHub uses the standard 5-field cron format `minute hour day-of-month month day-of-week`. Two patterns dominate this repo:
+
+- `0 8 D-31 * *` — "every day from the Dth to the end of the month at 08:00 UTC". Used as a "earliest plausible publication day onward" pattern.
+- `0 H DD * *` — "the DDth of each month at HH:00 UTC". Used for sources with a known fixed publication day (Brazil).
+
+If you need the *next* fire time for one of these, the easiest sanity check is the Actions tab — each workflow's run history shows the previous fire times, and from there the next one is +1 day (for daily windows) or +1 month (for monthly fixed-day crons).
+
+---
+
 ## 8.10 Restoring from disaster
 
 | Disaster | Recovery |
 |---|---|
 | Repo deleted / corrupted | Restore from any clone — every artefact is in Git |
-| Cloudflare account lost | Re-create Worker via wrangler, re-set secret, re-bind KV. The KV's rate-limit data is lost but uncritical. |
-| Maintainer's Mac lost | Clone the repo on a new machine, `wrangler login`, `gitcreds_set` for git OAuth, done. The local R scripts (`bev_share_*.R`) are off-repo and need to be restored from iCloud or a backup; if not, the in-repo `R/` pipeline alone is sufficient. |
-| GitHub down | Read-side serves from GitHub Pages CDN, may stay up briefly. Submit/feedback writes fail — Worker returns 502; page shows error. Wait for GitHub. |
+| Cloudflare account lost | Re-create Worker via wrangler, re-set secret, re-bind KV, re-link Workers Builds to the repo (Cloudflare → Workers → Settings → Builds → "Connect to Git"). The KV's rate-limit data is lost but uncritical. |
+| Workers Builds integration revoked | Manual deploy via `cd worker && npx wrangler@latest deploy` keeps the Worker fresh; re-link via the dashboard at convenience. The fallback is identical to the pre-integration deploy path, so no functional outage. |
+| Maintainer's Mac lost | Clone the repo on a new machine, `wrangler login`, `gitcreds_set` for git OAuth, done. The local R scripts (`bev_share_*.R`) are off-repo and need to be restored from iCloud or a backup; if not, the in-repo `R/` pipeline alone is sufficient. Worker pushes still deploy via Workers Builds without any Mac-side setup. |
+| GitHub down | Read-side serves from GitHub Pages CDN, may stay up briefly. Submit/feedback writes fail — Worker returns 502; page shows error. Workers Builds is also paused (no source to pull). Wait for GitHub. |
 
 ## See also
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -57,6 +57,7 @@ flowchart LR
 
     Actions -- "git push" --> Repo
     Repo -- "auto-deploy" --> Pages
+    Repo -- "Workers Builds: push worker/** → wrangler deploy" --> Worker
     Repo -- "push to images/** triggers build-manifest" --> Actions
     Maintainer -- "manual dispatch (render-country)" --> Actions
 


### PR DESCRIPTION
- 08-deploy-ops: new §8.1.1 Workers Builds (auto-deploy from Git) covering the GitHub↔Cloudflare integration; new §8.11 cron schedule overview consolidating all fetch + infrastructure workflows into one table.
- 05-flows: add Flow O (RDW/Swing, Netherlands) and Flow P (CPCA, China); fix duplicate "Flow L" heading (Snapshot Builder vs ACAU/Uruguay → L₂); repair the orphan mermaid block under the old duplicate.
- 02-components: §2.2 — describe Workers Builds deploy path; new §2.7 Fetch Actions overview listing all 9 country fetchers with source/scope/schedule and the manual-only country list; renumber downstream sections accordingly.
- 06-tech-stack + README index diagram + ADOIT brief: surface Workers Builds as a hosting/SaaS line, an auto-deploy edge in the big-picture mermaid, and a new external integration with its own trust-boundary entry.