### PR TITLE
fix: retry connection errors in Netherlands fetch script

### DIFF
--- a/.github/workflows/fetch-netherlands.yml
+++ b/.github/workflows/fetch-netherlands.yml
@@ -57,6 +57,9 @@ jobs:
             ${VARIANT:+--variant "$VARIANT"}
         env:
           VARIANT: ${{ inputs.variant }}
+        # The script retries connection errors up to 3× with backoff. A failure
+        # here means the RDW endpoint was unreachable for >~14 s — re-run manually
+        # once the site is back, or wait for the next scheduled run.
 
       - name: Detect which CSVs changed
         id: changed

--- a/docs/architecture/10-source-netherlands.md
+++ b/docs/architecture/10-source-netherlands.md
@@ -277,6 +277,7 @@ change, mirror the change in plots.R.
 
 | Failure mode | What happens | Diagnostic |
 |---|---|---|
+| GitHub Actions runner can't reach the host (transient `Network is unreachable` / `errno 101`) | `requests.Session` retries the connection up to 3× with exponential backoff (2 s → 4 s → 8 s); if all retries fail the job fails visibly | Re-run the workflow manually once the network recovers, or wait for the next scheduled run. The most recent confirmed occurrence was 2026-06-01. |
 | Maintainer deletes a saved permalink in Swing | Scraper fails on that variant with `WsGuid not found in /viewer response` | Look at the failing variant's URL in the Action log; recreate the permalink in Swing UI; update `TEMPLATES` in `fetch_netherlands.py` |
 | Swing upgrades to a version with a different inline-JS shape | `WSGUID_RE` regex stops matching | Update the regex to match the new JS pattern (look at the raw HTML response) |
 | Swing changes the pivot JSON shape | Parser fails noisily; render aborts before commit | Inspect a fresh HAR; update `parse_table` / `_parse_periods_in_rows` / `_parse_fuels_in_rows` |
@@ -337,8 +338,10 @@ match, the template GUID is broken. If step 2 returns HTML (a 302 to
 - Authentication. JIVE_AUTH is a server-side anti-CSRF token, not a user
   credential. The whole flow works for any anonymous client. Do not commit
   the maintainer's logged-in cookies anywhere.
-- A non-Swing fallback. If Swing is down, there is no automatic switch to
-  CBS Statline or anywhere else. The scraper just fails the action.
+- A non-Swing fallback. If Swing is persistently unreachable, there is no
+  automatic switch to CBS Statline or anywhere else. Transient connection
+  errors are retried up to 3× with exponential backoff (see Known fragility
+  above); a failure that survives all retries still fails the action.
 - Real-time updates. The cron is daily, not hourly. There is no webhook
   from RDW or Swing.
 - Backfill for Used/HDV before 2018. The maintainer's sheet doesn't have

--- a/scripts/fetch_netherlands.py
+++ b/scripts/fetch_netherlands.py
@@ -51,6 +51,8 @@ from datetime import date
 from pathlib import Path
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 BASE = "https://duurzamemobiliteit.databank.nl"
 
@@ -367,6 +369,13 @@ def main() -> None:
             return
 
     session = requests.Session()
+    # Retry up to 3 times on connection errors with exponential backoff (2s, 4s, 8s).
+    # Handles transient network-unreachable failures seen on GitHub Actions runners.
+    _retry = Retry(connect=3, read=2, backoff_factor=2, raise_on_status=False)
+    _adapter = HTTPAdapter(max_retries=_retry)
+    session.mount("https://", _adapter)
+    session.mount("http://", _adapter)
+
     for variant in targets:
         data = fetch_table(variant, session)
         print(f"[{variant}] caption: {data['caption']}")


### PR DESCRIPTION
GitHub Actions runners occasionally fail to reach duurzamemobiliteit.databank.nl
with errno 101 (Network is unreachable). The script had no retry logic so a single
transient network hiccup caused the whole job to fail.

Mounts a urllib3 Retry adapter on the requests.Session: 3 retries on connect
errors and 2 on read errors, with 2× exponential backoff (waits: 2 s, 4 s, 8 s).
Adds a workflow comment pointing to the manual re-run option for persistent failures.

https://claude.ai/code/session_01AzhFNsaD9tbZ8Yyrqero43