### PR TITLE
fix(portugal-ttm): recompute Other as residual so bars always sum to 100%

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -82,6 +82,20 @@ compute_ttm_long <- function(df) {
     any_present <- any_present & !is.na(rs)
   }
 
+  # Recompute OTHERS as the TTM residual (TOTAL minus all other known fuels) so
+  # that stacked bars always sum to 100%. This corrects under-filled OTHERS in
+  # historical ACAP data where the breakdown was incomplete or quarterly-averaged.
+  if ("OTHERS" %in% names(ttm) && length(ttm) > 1) {
+    excl <- setdiff(names(ttm), "OTHERS")
+    excl_counts <- lapply(excl, function(c) {
+      v <- ttm[[c]] * total_ttm
+      v[is.na(v)] <- 0
+      v
+    })
+    excl_sum <- Reduce("+", excl_counts)
+    ttm[["OTHERS"]] <- pmax(0, total_ttm - excl_sum) / total_ttm
+  }
+
   # Keep only rows where every present column has a complete 12-month window.
   keep <- which(any_present)
   if (length(keep) == 0) return(NULL)


### PR DESCRIPTION
Historical ACAP data for Portugal (2018–2022) had an under-filled OTHERS
column: quarterly-averaged PETROL/DIESEL values and missing monthly breakdowns
left a gap between the sum of known fuel types and TOTAL.

After computing the TTM rolling sums for all other fuel columns, recompute
OTHERS as max(0, TOTAL_ttm - sum_of_known_fuel_ttms). Working on 12-month
rolling sums (not individual months) means quarterly estimates cancel out
correctly, so the fix is accurate for all eras of ACAP data.

https://claude.ai/code/session_01RcRStisoEozqqBTqPibV49