### PR TITLE
data: Italy (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/Italy.csv
+++ b/data/Italy.csv
@@ -135,3 +135,4 @@ period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,note
 2026-02,monthly,Whole,unrae.it,12572.0,13525.0,82315.0,32012.0,10278.0,8008.0,158710.0,
 2026-03,monthly,Whole,unrae.it,16137.0,16998.0,93652.0,37678.0,12150.0,10073.0,186688.0,
 2026-04,monthly,Whole,unrae.it,13238,14184,76808,31850,10718,9550,156348,https://unrae.it/dati-statistici/immatricolazioni/7623/struttura-del-mercato-aprile-2026
+2026-05,monthly,Whole,unrae.it,13305,15433,71392,30956,10046,10527,151659,https://unrae.it/files/04%20Struttura%20del%20mercato%20Maggio%202026_6a1dab9620389.pdf


### PR DESCRIPTION
Submitted by **LeRaffl** via Submit Data form.

- **Country:** Italy
- **Variant:** Whole
- **Source:** unrae.it
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-05** (monthly) — BEV=13305, PHEV=15433, HEV=71392, PETROL=30956, DIESEL=10046, OTHERS=10527, TOTAL=151659

---

After merge, trigger the **Render country charts** Action to regenerate plots.