### PR TITLE
fix(render): add Rental to workflow_dispatch variant options

### DIFF
--- a/.github/workflows/render-country.yml
+++ b/.github/workflows/render-country.yml
@@ -33,6 +33,7 @@ on:
           - HDV
           - Industry
           - Private
+          - Rental
           - Vans
           - Buses
           - Pickups


### PR DESCRIPTION
## Summary

One-liner follow-up to #76 (Italy automation).

`Italy_Rental` was added in #76 but the hardcoded `options` list in `render-country.yml`'s `workflow_dispatch` block was not updated. This meant `Rental` was missing from the GitHub Actions UI dropdown when manually triggering a render.

**Not broken:** The `workflow_call` path (used by `fetch-italy.yml` to auto-dispatch renders) accepts a free-form string — no issue there. Only the manual UI dispatch was affected.

## Test plan

- [ ] Open the Actions tab → Render country charts → confirm `Rental` appears in the variant dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)