### PR TITLE
data: Germany (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/Germany.csv
+++ b/data/Germany.csv
@@ -171,3 +171,4 @@ period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,note
 2026-02,monthly,Whole,KBA,46275.0,24328.0,60510,48404.0,31338.0,497,211262.0,
 2026-03,monthly,Whole,KBA,70663.0,29996.0,87850,66959.0,37664.0,1029,294161.0,
 2026-04,monthly,Whole,KBA,64350,27546,70207,53420,32437,1203,249163,first submission via page
+2026-05,monthly,Whole,KBA,59969,27921,67545,51806,30547,1660,239448,https://www.kba.de/DE/Presse/Pressemitteilungen/Fahrzeugzulassungen/2026/pm21_2026_n_05_26_pm_komplett.html


### PR DESCRIPTION
Submitted by **LeRaffl** via Submit Data form.

- **Country:** Germany
- **Variant:** Whole
- **Source:** KBA
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-05** (monthly) — BEV=59969, PHEV=27921, HEV=67545, PETROL=51806, DIESEL=30547, OTHERS=1660, TOTAL=239448

---

After merge, trigger the **Render country charts** Action to regenerate plots.