### PR TITLE
chore(new-zealand): disable scheduled auto-fetch (Imperva-blocked)

### DIFF
--- a/.github/workflows/fetch-new-zealand.yml
+++ b/.github/workflows/fetch-new-zealand.yml
@@ -14,6 +14,17 @@ name: Fetch New Zealand data (transport.govt.nz)
 # Per-variant early-exit makes most runs no-ops once the latest month is in.
 #
 # See scripts/fetch_new_zealand.py and docs/architecture/19-source-new-zealand.md.
+#
+# STATUS (2026-06): auto-fetch disabled. Both sources are now behind Imperva
+# (Incapsula/Reese84) anti-bot:
+#   - transport.govt.nz/.../inner returns a 212-byte Incapsula challenge stub
+#     instead of the chart JSON.
+#   - catalogue.data.govt.nz CKAN API returns an Imperva "Pardon Our
+#     Interruption" HTML interstitial instead of JSON.
+# Plain `requests` from a GHA runner cannot pass either. The scheduled trigger
+# is removed; workflow_dispatch is kept so the workflow can still be invoked
+# manually (e.g. from a non-blocked host) until an alternate source is wired
+# up (Stats NZ API or NZTA open-data ArcGIS are the likely candidates).
 
 on:
   workflow_dispatch:
@@ -38,11 +49,9 @@ on:
         required: false
         default: 'false'
         type: boolean
-  schedule:
-    # Transport.govt.nz publishes monthly data around the 5th–10th.
-    # Poll twice daily on the 5th–12th (06:00 and 14:00 UTC).
-    - cron: '0 6  5-12 * *'
-    - cron: '0 14 5-12 * *'
+  # schedule: disabled — both upstream sources are behind Imperva (see header).
+  #   - cron: '0 6  5-12 * *'
+  #   - cron: '0 14 5-12 * *'
 
 jobs:
   fetch:

--- a/docs/architecture/19-source-new-zealand.md
+++ b/docs/architecture/19-source-new-zealand.md
@@ -1,5 +1,15 @@
 # 19 · Source: New Zealand (transport.govt.nz)
 
+> **Status (2026-06): auto-fetch disabled.** Both the primary `/inner`
+> endpoint and the `catalogue.data.govt.nz` CKAN fallback are now served
+> behind Imperva (Incapsula/Reese84). Plain `requests` from a GHA runner
+> receives a JS challenge stub / "Pardon Our Interruption" interstitial,
+> not data. The scheduled trigger in
+> `.github/workflows/fetch-new-zealand.yml` is commented out;
+> `workflow_dispatch` is retained for manual runs from an unblocked host.
+> An alternate ingestion path (Stats NZ API or NZTA open-data ArcGIS) is
+> the likely longer-term fix.
+
 The New Zealand Ministry of Transport (MoT) publishes monthly light motor
 vehicle registration statistics via an interactive fleet-statistics dashboard
 at `transport.govt.nz/statistics-and-insights/fleet-statistics`.


### PR DESCRIPTION
## Summary
- Both NZ sources are now behind Imperva (Incapsula/Reese84) and unreachable from GHA runners:
  - `transport.govt.nz/.../inner` → 212-byte Incapsula challenge stub instead of chart JSON
  - `catalogue.data.govt.nz` CKAN API → "Pardon Our Interruption" HTML interstitial instead of JSON
- Comment out the `schedule:` triggers; keep `workflow_dispatch` for manual runs from an unblocked host.
- Add a status banner to `docs/architecture/19-source-new-zealand.md` documenting the block and pointing at Stats NZ API / NZTA ArcGIS as likely longer-term replacements.

No code/script changes — the fetcher is left in place for when a working source path is wired up.

## Test plan
- [x] `cron:` lines no longer present in `on:` block (commented only)
- [x] `workflow_dispatch` still parses (unchanged inputs)
- [ ] Confirm no other workflow references the disabled schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)