### PR TITLE
feat(post): TTM market-split copy-post + format refinements

### DIFF
--- a/R/post_text.R
+++ b/R/post_text.R
@@ -170,15 +170,15 @@ build_post_text <- function(df, country_label, last_period = NULL) {
 
 # Companion post for the TTM market-split chart. Different shape from the
 # main BEV-trajectory post:
-#   <flag> <Country> - <Month YY> - TTM Market Split
-#   <prior 12m window>  vs  <current 12m window>
+#   <flag> <Country> - TTM Market Split
 #                                                # blank line
+#   <prior 12m window>  vs  <current 12m window>
 #   <±X.Xpp>  <BAND>  (<prior%> → <current%>)    # one per band, padded
 #   ...
 #                                                # blank line (only if extras)
 #   <PHEV/HEV peaked at X% in YYYY-MM (declining for N months).>
-#   <BEV would overtake X in YYYY-MM.>
-#   <BEV would become the largest powertrain in YYYY-MM.>
+#   <If the changes from the last 6 months continued linearly, BEV would overtake X in YYYY-MM.>
+#   <If the changes from the last 6 months continued linearly, BEV would become the largest powertrain in YYYY-MM.>
 #                                                # blank line
 #   Graphs are available in the Gallery: ...
 #
@@ -193,7 +193,7 @@ build_post_text <- function(df, country_label, last_period = NULL) {
   old <- Sys.getlocale("LC_TIME")
   on.exit(Sys.setlocale("LC_TIME", old), add = TRUE)
   Sys.setlocale("LC_TIME", "C")
-  paste(format(d, "%b"), format(d, "%y"))
+  paste0(format(d, "%b"), format(d, "%y"))
 }
 
 .pt_add_months <- function(period, n) {
@@ -340,10 +340,10 @@ build_ttm_post_text <- function(df, country_label, as_of_period = NULL) {
           ymd <- .pt_add_months(periods[cur], c1$months)
           if (j == n_cross) {
             cross_lines <- c(cross_lines,
-                             sprintf("BEV would become the largest powertrain in %s.", ymd))
+                             sprintf("If the changes from the last 6 months continued linearly, BEV would become the largest powertrain in %s.", ymd))
           } else if (largest_m - c1$months > 2L) {
             cross_lines <- c(cross_lines,
-                             sprintf("BEV would overtake %s in %s.", c1$label, ymd))
+                             sprintf("If the changes from the last 6 months continued linearly, BEV would overtake %s in %s.", c1$label, ymd))
           }
         }
       } else {
@@ -351,7 +351,7 @@ build_ttm_post_text <- function(df, country_label, as_of_period = NULL) {
         for (c1 in crossings) {
           ymd <- .pt_add_months(periods[cur], c1$months)
           cross_lines <- c(cross_lines,
-                           sprintf("BEV would overtake %s in %s.", c1$label, ymd))
+                           sprintf("If the changes from the last 6 months continued linearly, BEV would overtake %s in %s.", c1$label, ymd))
         }
       }
     }
@@ -359,13 +359,12 @@ build_ttm_post_text <- function(df, country_label, as_of_period = NULL) {
 
   # --- Compose ---
   flag <- .pt_flag(country_label)
-  header <- sprintf("%s %s - %s - TTM Market Split", flag, country_label,
-                    .pt_month_label(periods[cur]))
+  header <- sprintf("%s %s - TTM Market Split", flag, country_label)
   window_line <- sprintf("%s–%s  vs  %s–%s",
                          .pt_short_month(periods[pri - 11L]), .pt_short_month(periods[pri]),
                          .pt_short_month(periods[cur - 11L]), .pt_short_month(periods[cur]))
 
-  parts <- c(header, window_line, "", delta_lines)
+  parts <- c(header, "", window_line, delta_lines)
   extras <- c(peak_lines, cross_lines)
   if (length(extras) > 0L) parts <- c(parts, "", extras)
   parts <- c(parts, "", "Graphs are available in the Gallery: https://leraffl.github.io/LeRaffl-Gallery/")


### PR DESCRIPTION
## Summary
- Adds the TTM market-split companion post (Copy-post button), with band deltas, peak detection and crossover predictions
- Refines the rendered format: drops the redundant month from the header, tightens the spacing (blank line above the window line, none between window line and deltas), and uses compact `Jun24` instead of `Jun 24`
- Makes the linear-extrapolation assumption explicit: crossover lines now read "If the changes from the last 6 months continued linearly, BEV would …"

## Example output
```
🇩🇪 Germany - TTM Market Split

Jun24–May25  vs  Jun25–May26
+5.8pp  BEV   (15.8% → 21.6%)
+3.1pp  PHEV  (8.3% → 11.4%)
+0.4pp  HEV   (28.3% → 28.8%)
−9.3pp  ICE   (47.5% → 38.2%)

HEV peaked at 28.9% in 2025-09 (declining for 8 months).
If the changes from the last 6 months continued linearly, BEV would become the largest powertrain in 2027-08.

Graphs are available in the Gallery: https://leraffl.github.io/LeRaffl-Gallery/
```

## Test plan
- [ ] Open the Gallery, hit the Copy-post button on a TTM chart, verify the clipboard matches the format above
- [ ] Check a hybrid-only country (3-band: BEV / Hybrid / ICE)
- [ ] Check a country where BEV is not catching every band (overtake-only, no "becomes largest")

🤖 Generated with [Claude Code](https://claude.com/claude-code)