### PR TITLE
data: Australia (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/Australia.csv
+++ b/data/Australia.csv
@@ -74,3 +74,4 @@ period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,note
 2026-02,monthly,Whole,VFACTS & Prof. Ray Willis,11134.0,5854.0,13868.0,33309.0,26963.0,,91128.0,
 2026-03,monthly,Whole,VFACTS & Prof. Ray Willis,15839.0,8215.0,17953.0,34694.0,28364.0,,105065.0,
 2026-04,monthly,Whole,VFACTS & Prof. Ray Willis,15459,9628,18162,25399,22414,,91062,Check again for consistency
+2026-05,monthly,Whole,VFACTS & Prof. Ray Willis,21303,9315,19024,28692,25191,,103525,


### PR DESCRIPTION
Submitted by **Anonymous** via Submit Data form.

- **Country:** Australia
- **Variant:** Whole
- **Source:** VFACTS & Prof. Ray Willis
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-05** (monthly) — BEV=21303, PHEV=9315, HEV=19024, PETROL=28692, DIESEL=25191, TOTAL=103525

---

After merge, trigger the **Render country charts** Action to regenerate plots.