### PR TITLE
data: New Zealand (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/New Zealand.csv
+++ b/data/New Zealand.csv
@@ -171,3 +171,4 @@ period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,note
 2026-02,monthly,Whole,transport.govt.nz & Prof. Ray Willis,841.0,773.0,5809.0,6584.0,2969.0,0.0,16976.0,
 2026-03,monthly,Whole,transport.govt.nz & Prof. Ray Willis,2992.0,1566.0,8307.0,6351.0,3769.0,1.0,22986.0,
 2026-04,monthly,Whole,transport.govt.nz & Prof. Ray Willis,1415,1273,6996,7265,2418,0,19367,https://www.transport.govt.nz/statistics-and-insights/fleet-statistics/light-motor-vehicle-registrations/
+2026-05,monthly,Whole,transport.govt.nz & Prof. Ray Willis,1962,1115,6792,6560,3261,,19690,


### PR DESCRIPTION
Submitted by **Anonymous** via Submit Data form.

- **Country:** New Zealand
- **Variant:** Whole
- **Source:** transport.govt.nz & Prof. Ray Willis
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-05** (monthly) — BEV=1962, PHEV=1115, HEV=6792, PETROL=6560, DIESEL=3261, TOTAL=19690

---

After merge, trigger the **Render country charts** Action to regenerate plots.