### PR TITLE
data: Thailand (Whole) — 2 added, 1 corrected

### DIFF
--- a/data/Thailand.csv
+++ b/data/Thailand.csv
@@ -96,4 +96,6 @@ period,time_interval,variant,source,BEV,PHEV,HEV,OTHERS,ICE,TOTAL,notes
 2025-11,monthly,Whole,data.thaiauto.or.th,10674.0,1067.0,10733.0,0.0,21732.0,44206.0,
 2025-12,monthly,Whole,data.thaiauto.or.th,14591.0,861.0,8219.0,0.0,19028.0,42700.0,
 2026-01,monthly,Whole,data.thaiauto.or.th,42209.0,1978.0,17174.0,0.0,31142.0,92503.0,
-2026-02,monthly,Whole,data.thaiauto.or.th,4830.0,1024.0,14569.0,,28511.0,48934.0,
+2026-02,monthly,Whole,data.thaiauto.or.th,4830,1021,14569,3,28511,48934,plus Robbie check
+2026-03,monthly,Whole,data.thaiauto.or.th,10130,1172,16118,5,32171,59596,plus Robbie check
+2026-04,monthly,Whole,data.thaiauto.or.th,10030,1280,12641,16,25140,49107,plus Robbie check


### PR DESCRIPTION
Submitted by **LeRaffl** via Submit Data form.

- **Country:** Thailand
- **Variant:** Whole
- **Source:** data.thaiauto.or.th
- **Added:** 2
- **Corrected:** 1

### Corrections

**2026-02**

| field | before | after |
|---|---|---|
| BEV | 4830.0 | 4830 |
| PHEV | 1024.0 | 1021 |
| HEV | 14569.0 | 14569 |
| OTHERS | _(empty)_ | 3 |
| ICE | 28511.0 | 28511 |
| TOTAL | 48934.0 | 48934 |

### New rows
- **2026-03** (monthly) — BEV=10130, PHEV=1172, HEV=16118, OTHERS=5, ICE=32171, TOTAL=59596
- **2026-04** (monthly) — BEV=10030, PHEV=1280, HEV=12641, OTHERS=16, ICE=25140, TOTAL=49107

---

After merge, trigger the **Render country charts** Action to regenerate plots.