### PR TITLE
data: estimate Italy Rental + NonRental history back to 2015

### DIFF
--- a/data/Italy_NonRental.csv
+++ b/data/Italy_NonRental.csv
@@ -1,4 +1,57 @@
 period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,notes
+2015-01,quarterly,NonRental,unrae.it,86,1081,236,,,,105612,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-02,quarterly,NonRental,unrae.it,69,950,208,,,,108045,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-03,quarterly,NonRental,unrae.it,197,1217,267,,,,129414,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-04,quarterly,NonRental,unrae.it,55,1004,220,,,,118801,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-05,quarterly,NonRental,unrae.it,55,1077,236,,,,117233,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-06,quarterly,NonRental,unrae.it,91,1153,253,,,,117187,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-07,quarterly,NonRental,unrae.it,54,832,182,,,,105412,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-08,quarterly,NonRental,unrae.it,26,416,91,,,,47468,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-09,quarterly,NonRental,unrae.it,48,1310,287,,,,104453,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-10,quarterly,NonRental,unrae.it,54,1207,265,,,,106809,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-11,quarterly,NonRental,unrae.it,53,1221,267,,,,107805,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-12,quarterly,NonRental,unrae.it,69,1181,259,,,,89322,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-01,quarterly,NonRental,unrae.it,69,1650,361,,,,125608,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-02,quarterly,NonRental,unrae.it,56,1787,391,,,,139304,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-03,quarterly,NonRental,unrae.it,120,1671,366,,,,153780,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-04,quarterly,NonRental,unrae.it,58,1515,332,,,,135414,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-05,quarterly,NonRental,unrae.it,56,1820,399,,,,151443,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-06,quarterly,NonRental,unrae.it,51,1563,342,,,,133271,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-07,quarterly,NonRental,unrae.it,43,1354,297,,,,110490,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-08,quarterly,NonRental,unrae.it,29,775,170,,,,57933,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-09,quarterly,NonRental,unrae.it,87,1996,438,,,,124508,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-10,quarterly,NonRental,unrae.it,88,1739,381,,,,119098,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-11,quarterly,NonRental,unrae.it,65,1769,388,,,,119282,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-12,quarterly,NonRental,unrae.it,118,1767,387,,,,102786,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-01,monthly,NonRental,unrae.it,113,2360,517,,,,138072,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-02,monthly,NonRental,unrae.it,72,85,4296,54496,69374,13095,141418,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-03,monthly,NonRental,unrae.it,138,100,4626,66889,85661,15943,173357,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-04,monthly,NonRental,unrae.it,75,92,3716,44772,62939,10740,122334,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-05,monthly,NonRental,unrae.it,90,128,5451,60316,76662,14186,156833,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-06,monthly,NonRental,unrae.it,117,235,4847,49505,74479,14170,143353,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-07,monthly,NonRental,unrae.it,87,154,4168,40258,55066,12338,112071,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-08,monthly,NonRental,unrae.it,59,88,2294,22031,32530,7021,64023,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-09,monthly,NonRental,unrae.it,110,198,4639,45866,65209,11916,127938,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-10,monthly,NonRental,unrae.it,141,173,5243,44345,59411,12928,122241,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-11,monthly,NonRental,unrae.it,93,144,5389,41953,59812,13318,120709,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-12,monthly,NonRental,unrae.it,119,131,3877,32712,47841,9992,94672,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-01,monthly,NonRental,unrae.it,155,179,5642,51538,66224,13251,136989,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-02,monthly,NonRental,unrae.it,148,141,5094,51543,68724,13588,139238,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-03,monthly,NonRental,unrae.it,250,208,5832,64254,77973,15549,164066,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-04,monthly,NonRental,unrae.it,146,107,5732,52035,60583,13561,132164,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-05,monthly,NonRental,unrae.it,357,177,6072,62166,68931,16374,154077,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-06,monthly,NonRental,unrae.it,265,400,5896,51225,61824,15166,134776,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-07,monthly,NonRental,unrae.it,386,371,5922,44799,52187,14459,118124,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-08,monthly,NonRental,unrae.it,114,217,3053,23724,34551,8506,70165,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-09,monthly,NonRental,unrae.it,294,189,6037,42999,40238,7874,97631,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-10,monthly,NonRental,unrae.it,353,315,6675,54339,43357,10759,115798,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-11,monthly,NonRental,unrae.it,278,220,6232,53135,44501,11449,115815,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-12,monthly,NonRental,unrae.it,229,93,4485,51284,34713,8380,99184,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2019-01,monthly,NonRental,unrae.it,170,204,6715,65995,45551,12747,131382,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2019-02,monthly,NonRental,unrae.it,152,155,7489,66986,53688,11339,139809,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2019-03,monthly,NonRental,unrae.it,374,264,8066,70826,58830,14315,152675,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2019-04,monthly,NonRental,unrae.it,718,311,7316,69277,47452,13874,138948,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2019-05,monthly,NonRental,unrae.it,705,276,8325,76387,55468,15472,156633,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
 2019-06,monthly,NonRental,unrae.it,1044,290,7428,60900,44233,14293,128188,
 2019-07,monthly,NonRental,unrae.it,582,212,6698,61892,40512,16563,126459,
 2019-08,monthly,NonRental,unrae.it,352,152,3246,35184,25983,10524,75441,

--- a/data/Italy_Rental.csv
+++ b/data/Italy_Rental.csv
@@ -1,4 +1,57 @@
 period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,notes
+2015-01,quarterly,Rental,unrae.it,57,797,54,,,,26894,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-02,quarterly,Rental,unrae.it,46,701,47,,,,27514,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-03,quarterly,Rental,unrae.it,130,898,60,,,,32955,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-04,quarterly,Rental,unrae.it,36,740,50,,,,30253,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-05,quarterly,Rental,unrae.it,37,794,54,,,,29854,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-06,quarterly,Rental,unrae.it,60,851,57,,,,29842,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-07,quarterly,Rental,unrae.it,36,613,41,,,,26843,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-08,quarterly,Rental,unrae.it,17,306,21,,,,12088,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-09,quarterly,Rental,unrae.it,32,966,65,,,,26599,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-10,quarterly,Rental,unrae.it,36,891,60,,,,27199,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-11,quarterly,Rental,unrae.it,35,900,61,,,,27453,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2015-12,quarterly,Rental,unrae.it,46,871,59,,,,22746,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-01,quarterly,Rental,unrae.it,46,1217,82,,,,31986,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-02,quarterly,Rental,unrae.it,37,1318,89,,,,35474,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-03,quarterly,Rental,unrae.it,79,1232,83,,,,39160,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-04,quarterly,Rental,unrae.it,38,1118,75,,,,34483,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-05,quarterly,Rental,unrae.it,37,1342,90,,,,38565,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-06,quarterly,Rental,unrae.it,33,1152,78,,,,33938,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-07,quarterly,Rental,unrae.it,28,999,67,,,,28137,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-08,quarterly,Rental,unrae.it,19,571,38,,,,14753,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-09,quarterly,Rental,unrae.it,57,1472,99,,,,31706,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-10,quarterly,Rental,unrae.it,58,1283,87,,,,30328,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-11,quarterly,Rental,unrae.it,43,1304,88,,,,30376,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2016-12,quarterly,Rental,unrae.it,78,1304,88,,,,26175,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-01,monthly,Rental,unrae.it,75,1741,117,,,,35160,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-02,monthly,Rental,unrae.it,48,63,974,7313,34717,1198,44313,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-03,monthly,Rental,unrae.it,91,74,1050,8975,42869,1459,54518,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-04,monthly,Rental,unrae.it,49,68,843,6008,31497,983,39448,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-05,monthly,Rental,unrae.it,59,94,1236,8093,38365,1298,49145,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-06,monthly,Rental,unrae.it,78,173,1100,6643,37273,1297,46564,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-07,monthly,Rental,unrae.it,58,114,946,5402,27558,1129,35207,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-08,monthly,Rental,unrae.it,39,65,520,2956,16279,642,20501,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-09,monthly,Rental,unrae.it,72,146,1053,6155,32633,1090,41149,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-10,monthly,Rental,unrae.it,94,128,1190,5950,29732,1183,38277,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-11,monthly,Rental,unrae.it,61,107,1223,5629,29932,1219,38171,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2017-12,monthly,Rental,unrae.it,78,97,879,4389,23942,914,30299,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-01,monthly,Rental,unrae.it,103,132,1280,6915,33141,1212,42783,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-02,monthly,Rental,unrae.it,98,104,1155,6916,34393,1243,43909,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-03,monthly,Rental,unrae.it,166,153,1323,8622,39021,1423,50708,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-04,monthly,Rental,unrae.it,97,79,1300,6982,30318,1241,40017,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-05,monthly,Rental,unrae.it,237,130,1377,8342,34496,1498,46080,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-06,monthly,Rental,unrae.it,175,295,1338,6874,30939,1388,41009,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-07,monthly,Rental,unrae.it,255,274,1344,6011,26116,1323,35323,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-08,monthly,Rental,unrae.it,76,160,692,3183,17291,778,22180,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-09,monthly,Rental,unrae.it,195,140,1370,5770,20137,720,28332,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-10,monthly,Rental,unrae.it,234,233,1514,7291,21698,985,31955,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-11,monthly,Rental,unrae.it,184,163,1414,7130,22270,1048,32209,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2018-12,monthly,Rental,unrae.it,151,68,1017,6881,17372,767,26256,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2019-01,monthly,Rental,unrae.it,113,151,1523,8856,22796,1166,34605,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2019-02,monthly,Rental,unrae.it,101,114,1699,8988,26867,1038,38807,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2019-03,monthly,Rental,unrae.it,248,194,1830,9504,29441,1310,42527,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2019-04,monthly,Rental,unrae.it,475,229,1660,9296,23747,1269,36676,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
+2019-05,monthly,Rental,unrae.it,467,204,1889,10250,27758,1416,41984,est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data
 2019-06,monthly,Rental,unrae.it,410,106,1764,13290,28495,1219,45284,
 2019-07,monthly,Rental,unrae.it,361,166,1690,7105,17060,1466,27848,
 2019-08,monthly,Rental,unrae.it,185,155,855,4034,8284,757,14270,

--- a/docs/architecture/18-source-italy.md
+++ b/docs/architecture/18-source-italy.md
@@ -131,6 +131,22 @@ The renderer is unaffected: it always filters TTM/recent calculations on
 rows are intentionally left as-is rather than corrected, to signal their lower
 resolution. Do not re-label them `monthly`.
 
+### Rental / NonRental history & provenance
+
+| Period | Rental / NonRental source | notes column |
+|---|---|---|
+| 2019-06 → present | **Real.** UNRAE "al netto del noleggio" block; `Rental = Whole − netto`, `NonRental = Whole − Rental` (exact). | empty |
+| 2015-01 → 2019-05 | **Estimated.** No rental block exists in pre-2019-06 UNRAE PDFs, so `Rental = round(Whole × per-fuel rental share)` using the 2019-H2 actual shares; `NonRental = Whole − Rental`. | `est: Whole x rental-share(2019-H2); …` |
+| 2020-04 | **Omitted** from Rental & NonRental — COVID-lockdown data-revision anomaly (PDF rental BEV > recorded Whole BEV). | — |
+
+The 2019-H2 reference shares (BEV 39.8 %, PHEV 42.4 %, HEV 18.5 %, PETROL
+11.8 %, DIESEL 33.4 %, OTHERS 8.4 %, TOTAL 20.3 %) are the earliest *real*
+rental data, pre-COVID and closest in time to the estimated span. Estimated
+rows satisfy `Rental + NonRental == Whole` exactly. The 2015–2016 estimates
+inherit the lower resolution of the underlying quarterly Whole rows (only
+BEV/PHEV/HEV + TOTAL populated). Regenerate with
+`scripts/estimate_italy_rental_history.py` (pure CSV arithmetic, no network).
+
 ## 2. PKW flow (Whole + Rental)
 
 UNRAE has no public data API. The PKW bulletin is a two-page PDF:
@@ -277,3 +293,9 @@ Dispatch `fetch-italy.yml` with manual inputs to bypass discovery:
 - **PKW PDF layout dependency.** If UNRAE restructures the Struttura del
   mercato (column order, section headings, fuel naming), the strict sanity
   check guards against silent misparses.
+- **Pre-2019-06 Rental/NonRental are estimates.** UNRAE PDFs before 2019-06
+  carry no rental breakdown; those rows are modelled from Whole × 2019-H2
+  rental shares and flagged in the `notes` column (see §2). They assume a
+  flat rental share back through 2015 — adequate for fitting the long-run
+  adoption curve, but not month-accurate, and 2015–2016 inherit the
+  quarterly-approximation resolution of their Whole source.

--- a/scripts/estimate_italy_rental_history.py
+++ b/scripts/estimate_italy_rental_history.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Estimate the historical Rental / NonRental split for Italy for the periods
+that predate the first UNRAE 'al netto del noleggio' bulletin (2019-06).
+
+Why estimates
+-------------
+UNRAE 'struttura del mercato' PDFs before 2019-06 do NOT contain the rental
+("al netto del noleggio") breakdown, so no *real* Rental/NonRental split
+exists for 2015-01 .. 2019-05.  We approximate it by applying the per-fuel
+rental SHARE observed in the earliest real data — 2019-06 .. 2019-12, the
+closest pre-COVID window — to the historical Whole figures in Italy.csv:
+
+    Rental_est[fuel]    = round(Whole[fuel] * share[fuel])
+    NonRental_est[fuel] = Whole[fuel] - Rental_est[fuel]
+
+so that Rental + NonRental == Whole exactly for every populated column.
+
+Reference per-fuel shares (computed at runtime from 2019-H2 actuals; the
+values below are for reference):
+    BEV 39.8%  PHEV 42.4%  HEV 18.5%  PETROL 11.8%  DIESEL 33.4%  OTHERS 8.4%
+    TOTAL 20.3%
+
+Two regimes
+-----------
+* 2017-02 .. 2019-05 — Italy.csv carries the full real fuel breakdown, so
+  every fuel is estimated and Rental TOTAL = sum of the fuel rentals.
+* 2015-01 .. 2017-01 — Italy.csv only carries BEV/PHEV/HEV (themselves a
+  rough earlier backfill) plus TOTAL; petrol/diesel/others are blank.  Those
+  rows are mirrored: the three populated fuels are estimated per share and
+  TOTAL is estimated with the overall rental share; the rest stay blank.
+
+Every row written here is tagged in the notes column.  Real values
+(2019-06 onward) are never touched.
+
+Usage
+-----
+    python scripts/estimate_italy_rental_history.py
+    python scripts/estimate_italy_rental_history.py --dry-run
+"""
+import argparse
+import csv
+from pathlib import Path
+
+WHOLE_CSV     = "data/Italy.csv"
+RENTAL_CSV    = "data/Italy_Rental.csv"
+NONRENTAL_CSV = "data/Italy_NonRental.csv"
+
+FUELS   = ["BEV", "PHEV", "HEV", "PETROL", "DIESEL", "OTHERS"]
+NUMERIC = FUELS + ["TOTAL"]
+CSV_COLUMNS = ["period", "time_interval", "variant", "source", *NUMERIC, "notes"]
+
+# First UNRAE bulletin carrying the rental ("al netto del noleggio") section.
+FIRST_REAL = "2019-06"
+# Reference window for per-fuel rental shares: earliest real data, pre-COVID.
+REF_WINDOW = [f"2019-{m:02d}" for m in range(6, 13)]
+
+NOTE = "est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data"
+
+
+def _load(path: str, variant: str) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    with open(path, newline="", encoding="utf-8") as f:
+        for r in csv.DictReader(f):
+            if r.get("variant") == variant:
+                out[r["period"]] = r
+    return out
+
+
+def _to_int(s: str) -> int:
+    s = (s or "").strip()
+    if s == "":
+        return 0
+    if "." in s or "," in s:
+        return int(round(float(s.replace(",", "."))))
+    return int(s)
+
+
+def _is_blank(s: str) -> bool:
+    return (s or "").strip() == ""
+
+
+def compute_shares(whole: dict, rental: dict) -> dict:
+    """Per-fuel rental share = sum(Rental)/sum(Whole) over the reference window."""
+    sw = {c: 0 for c in NUMERIC}
+    sr = {c: 0 for c in NUMERIC}
+    for p in REF_WINDOW:
+        if p in whole and p in rental:
+            for c in NUMERIC:
+                sw[c] += _to_int(whole[p][c])
+                sr[c] += _to_int(rental[p][c])
+    return {c: (sr[c] / sw[c] if sw[c] else 0.0) for c in NUMERIC}
+
+
+def estimate_rows(whole_row: dict, period: str, share: dict) -> tuple[dict, dict]:
+    """Return (rental_row, nonrental_row) estimated from a Whole row."""
+    full = not _is_blank(whole_row.get("PETROL", ""))
+
+    rental_cols: dict[str, object] = {}
+    nonrental_cols: dict[str, object] = {}
+
+    for c in FUELS:
+        if _is_blank(whole_row.get(c, "")):
+            rental_cols[c] = ""
+            nonrental_cols[c] = ""
+        else:
+            w = _to_int(whole_row[c])
+            r = round(w * share[c])
+            rental_cols[c] = r
+            nonrental_cols[c] = w - r
+
+    if full:
+        # Real, complete breakdown → TOTAL is the sum of the fuel estimates.
+        r_total = sum(rental_cols[c] for c in FUELS)
+        n_total = sum(nonrental_cols[c] for c in FUELS)
+    else:
+        # Partial source (2015-2016) → use the overall rental share on TOTAL.
+        w_total = _to_int(whole_row["TOTAL"])
+        r_total = round(w_total * share["TOTAL"])
+        n_total = w_total - r_total
+    rental_cols["TOTAL"] = r_total
+    nonrental_cols["TOTAL"] = n_total
+
+    common = {
+        "period": period,
+        "time_interval": whole_row.get("time_interval", "monthly"),
+        "source": whole_row.get("source", "unrae.it"),
+        "notes": NOTE,
+    }
+    rental_row = {**common, "variant": "Rental", **rental_cols}
+    nonrental_row = {**common, "variant": "NonRental", **nonrental_cols}
+    return rental_row, nonrental_row
+
+
+def _merge_write(path: str, variant: str, new_rows: dict, dry_run: bool) -> int:
+    """Insert new_rows (period->row) into the CSV, never overwriting existing
+    periods. Returns the number of rows added."""
+    rows: list[dict] = []
+    existing: set[str] = set()
+    with open(path, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            for c in CSV_COLUMNS:
+                row.setdefault(c, "")
+            rows.append(row)
+            if row.get("variant") == variant:
+                existing.add(row["period"])
+
+    added = 0
+    for p, row in sorted(new_rows.items()):
+        if p in existing:
+            continue
+        rows.append(row)
+        added += 1
+
+    rows.sort(key=lambda r: (r.get("variant", ""), r["period"]))
+
+    if not dry_run:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=CSV_COLUMNS, lineterminator="\n")
+            w.writeheader()
+            w.writerows(rows)
+    return added
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Show what would be written; do not modify files.")
+    args = ap.parse_args()
+
+    whole  = _load(WHOLE_CSV, "Whole")
+    rental = _load(RENTAL_CSV, "Rental")
+
+    share = compute_shares(whole, rental)
+    print("Per-fuel rental shares from 2019-H2 actuals:")
+    for c in NUMERIC:
+        print(f"  {c:7s} {share[c]*100:5.1f}%")
+
+    targets = sorted(p for p in whole if p < FIRST_REAL and p not in rental)
+    print(f"\n{len(targets)} period(s) to estimate: {targets[0]} .. {targets[-1]}")
+
+    new_rental: dict[str, dict] = {}
+    new_nonrental: dict[str, dict] = {}
+    for p in targets:
+        r_row, n_row = estimate_rows(whole[p], p, share)
+        new_rental[p] = r_row
+        new_nonrental[p] = n_row
+
+    # Show a couple of samples.
+    for p in (targets[0], "2017-02" if "2017-02" in new_rental else targets[-1], targets[-1]):
+        r = new_rental[p]
+        print(f"  {p}  Rental BEV={r['BEV']} PHEV={r['PHEV']} HEV={r['HEV']} "
+              f"PETROL={r['PETROL']} DIESEL={r['DIESEL']} OTHERS={r['OTHERS']} "
+              f"TOTAL={r['TOTAL']}")
+
+    n_r = _merge_write(RENTAL_CSV, "Rental", new_rental, args.dry_run)
+    n_n = _merge_write(NONRENTAL_CSV, "NonRental", new_nonrental, args.dry_run)
+    verb = "Would add" if args.dry_run else "Added"
+    print(f"\n{verb} {n_r} Rental and {n_n} NonRental estimated row(s).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Extends `Italy_Rental.csv` and `Italy_NonRental.csv` back to **2015-01** (both previously started 2019-06). Adds **53 estimated months** per variant.

## Why estimates?

UNRAE "struttura del mercato" PDFs before **2019-06** carry no "al netto del noleggio" (rental) section — confirmed during the earlier real backfill. So no *real* Rental/NonRental split exists for 2015-01 → 2019-05. Real values from 2019-06 onward are **untouched**.

## Method

Apply the per-fuel rental **share** from the earliest real, pre-COVID data (**2019-06 → 2019-12**) to the historical Whole figures already in `Italy.csv`:

```
Rental_est[fuel]    = round(Whole[fuel] × share[fuel])
NonRental_est[fuel] = Whole[fuel] − Rental_est[fuel]
```

Reference shares (closest-in-time, pre-pandemic anchor):

| BEV | PHEV | HEV | PETROL | DIESEL | OTHERS | TOTAL |
|---|---|---|---|---|---|---|
| 39.8% | 42.4% | 18.5% | 11.8% | 33.4% | 8.4% | 20.3% |

Every estimated row is flagged in the **`notes`** column:
`est: Whole x rental-share(2019-H2); no pre-2019-06 UNRAE rental data`

## Two regimes

- **2017-02 → 2019-05** — full real Whole breakdown ⇒ all fuels estimated, `Rental TOTAL = Σ fuel rentals`.
- **2015-01 → 2017-01** — Whole only carries BEV/PHEV/HEV + TOTAL (quarterly approximation); those rows are mirrored — three fuels + TOTAL estimated, petrol/diesel/others left blank, inheriting the lower source resolution.

## Validation

- ✅ `Rental ≤ Whole` for every fuel/period
- ✅ `Rental + NonRental == Whole` exactly (additive)
- ✅ no negative values
- ✅ both CSVs now span 2015-01 → 2026-05 with complete coverage (2020-04 still omitted — COVID anomaly)

## Reproducible

`scripts/estimate_italy_rental_history.py` — pure CSV arithmetic, **no network / no PDFs**. Re-run anytime; it never overwrites existing periods.

Methodology documented in `docs/architecture/18-source-italy.md` (§2 + Known limitations).

---
_Generated by [Claude Code](https://claude.ai/code/session_017eZcuGf31rdfoWKCU1jd1c)_