### PR TITLE
docs: document estimated-value convention + Italy Rental/NonRental variants

### DIFF
--- a/docs/architecture/03-data-objects.md
+++ b/docs/architecture/03-data-objects.md
@@ -87,6 +87,19 @@ if not new_row["notes"] and old is not None:
 
 Scripts that build `new_row` with meaningful notes (Brazil, Netherlands, Japan, China — where `notes` carries provenance) always populate it explicitly, so the preservation guard is a no-op for them.
 
+**Estimated-value convention.** When a row's figures are **modelled rather than
+observed** (a real source value is unavailable for that period), the row is
+written with a short provenance phrase in `notes` so the estimate is never
+mistaken for ground truth. The phrase states *how* the estimate was derived, in
+one line. Current example: Italy's `Rental`/`NonRental` split before `2019-06`
+— UNRAE PDFs carry no rental breakdown that far back, so those rows are
+`Whole × 2019-H2 rental share` and tagged
+`est: Whole x rental-share(2019-H2); …` (see
+[18-source-italy.md § Rental/NonRental history](18-source-italy.md) and
+`scripts/estimate_italy_rental_history.py`). Estimated rows still satisfy every
+structural invariant (here `Rental + NonRental == Whole`); only their origin
+differs. An empty `notes` therefore means "directly from the source".
+
 ### Owner / lifecycle
 
 - **Author**: Maintainer (when transcribing from source) or Public Visitor (via Submit Data form, then merged after review).

--- a/docs/architecture/03-data-objects.md
+++ b/docs/architecture/03-data-objects.md
@@ -98,7 +98,9 @@ one line. Current example: Italy's `Rental`/`NonRental` split before `2019-06`
 [18-source-italy.md § Rental/NonRental history](18-source-italy.md) and
 `scripts/estimate_italy_rental_history.py`). Estimated rows still satisfy every
 structural invariant (here `Rental + NonRental == Whole`); only their origin
-differs. An empty `notes` therefore means "directly from the source".
+differs. An empty `notes` means "directly from the source" **for rows written
+or reviewed under this convention (June 2026 onward)**; legacy rows predating
+it may also carry empty `notes` simply because the convention didn't exist yet.
 
 ### Owner / lifecycle
 

--- a/docs/architecture/09-glossary.md
+++ b/docs/architecture/09-glossary.md
@@ -54,6 +54,16 @@ A **variant** is a within-country slice rendered as its own gallery entry (own C
 | `Vans` | **Light commercial** goods vehicles (vans, pickups). | **N1** (≤ 3.5 t) | |
 | `HDV` | **Heavy goods** vehicles (lorries / trucks — freight, not people). | **N2 + N3** (> 3.5 t) | See the cross-country deviation note below. |
 | `Buses` | **Buses & coaches.** | **M2 + M3** | Very low volume in most countries → lumpy, batch-driven fleet orders make the TTM share swing hard (this is real, not a bug — see e.g. Ireland Buses). |
+| `Rental` | Passenger cars registered to the **short-/long-term rental channel** ("noleggio"). | M1 | Italy only. `Rental = Whole − (al netto del noleggio)` from the UNRAE PDF. Real from `2019-06`; **estimated before that** (flagged in `notes`). `Rental + NonRental = Whole`. |
+| `NonRental` | Passenger cars registered **outside** the rental channel (private + company + self-registration). | M1 | Italy only. The UNRAE "al netto del noleggio" block; derived as `Whole − Rental`. Same real/estimated cutover as `Rental`. |
+
+> **Italy estimated history.** Both `Rental` and `NonRental` are *real* from
+> `2019-06` (first UNRAE bulletin with the rental block) and **modelled** for
+> `2015-01 … 2019-05` by applying the 2019-H2 per-fuel rental share to `Whole`.
+> Every estimated row is flagged in its `notes` column; `2020-04` is omitted
+> from both (COVID-lockdown data anomaly). See
+> [18-source-italy.md](18-source-italy.md) and
+> [03-data-objects.md § Estimated-value convention](03-data-objects.md).
 
 ### Per-country variant → source category
 
@@ -99,7 +109,7 @@ The HDV intent is "heavy goods vehicles > 3.5 t = N2 + N3". Most sources expose 
 |---|---|---|
 | **slug** | Lowercase form of country (and optionally variant) with non-alphanumerics replaced by `_`. Used in image filenames and post filenames. | `germany`, `new_zealand`, `denmark_hdv` |
 | **country** | The display name of the country | `Germany`, `Türkiye`, `New Zealand` |
-| **variant** | A within-country slice | `Whole` (default — labelled "New Cars" in the UI), `Custom`, `HDV`, `Vans`, `Private`, `Industry`, `2-Wheelers`, `3-Wheelers`, `4-Wheelers`, `Used`, `Used Imports`, `Fleet` |
+| **variant** | A within-country slice | `Whole` (default — labelled "New Cars" in the UI), `Custom`, `HDV`, `Vans`, `Private`, `Industry`, `Rental`, `NonRental`, `2-Wheelers`, `3-Wheelers`, `4-Wheelers`, `Used`, `Used Imports`, `Fleet` |
 | **type** (in chart filenames) | One of the four canonical chart types | empty (BEV trajectory), `ICE_BEV`, `time`, `ttm_shares` |
 
 ## Model parameters


### PR DESCRIPTION
## What

Pulls the Italy Rental/NonRental estimation approach into the **general, cross-country documentation** — not just the Italy-specific source playbook (which was already updated in #102). Docs-only, no code or data.

## Changes

**`03-data-objects.md` — new "Estimated-value convention"** (next to the `notes`-column contract)
- Establishes the repo-wide rule: when a row is *modelled rather than observed*, `notes` carries a one-line provenance phrase, so an estimate is never mistaken for source data.
- **Empty `notes` ⇒ directly from the source.**
- Uses Italy's pre-2019-06 split as the worked example.

**`09-glossary.md` — `Rental` / `NonRental` now in the canonical variant tables**
- These two variants were missing from the glossary entirely; added to both the canonical definitions table and the variant enumeration.
- Includes a callout: both are **real from 2019-06**, **estimated for 2015-01 … 2019-05** (flagged in `notes`), `2020-04` omitted (COVID anomaly), `Rental + NonRental = Whole`.

## Both variants covered?

Yes — Rental **and** NonRental are documented and handled identically (same real/estimated cutover, additive to Whole).

## Context

- Data + script + Italy source doc: merged in #101 (real 2019-06→2020-12) and #102 (estimates back to 2015).
- This PR is the general-doc layer you asked for, kept separate for easy review.

Cross-links added between `03-data-objects.md`, `09-glossary.md`, and `18-source-italy.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017eZcuGf31rdfoWKCU1jd1c)_