### PR TITLE
fix(charts): label combined hybrid bucket as "Hybrid" in TTM split

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -103,8 +103,18 @@ compute_ttm_long <- function(df) {
   out <- data.frame(month = months, stringsAsFactors = FALSE)
   for (col in names(ttm)) out[[col]] <- ttm[[col]][keep]
 
+  # Some sources report a single combined hybrid figure (PHEV + HEV + MHEV
+  # lumped together) which the pipeline parks in the HEV column with PHEV/EREV/
+  # MHEV left empty (e.g. Colombia, Türkiye, Georgia). There "HEV" is a misnomer
+  # — the bucket is all hybrids — so label it "Hybrid", matching the post text
+  # (.pt_triplet_lines). When PHEV/EREV/MHEV carry their own data the HEV column
+  # is genuine full-hybrid and keeps its label.
+  hev_combined <- ("HEV" %in% names(out)) &&
+    !any(c("PHEV", "EREV", "MHEV") %in% names(out))
+
   # Display labels: title-case for ICE-fuel families, keep acronyms as-is.
   display_label <- function(c) {
+    if (c == "HEV" && hev_combined) return("Hybrid")
     if (c %in% c("BEV","PHEV","EREV","HEV","MHEV","CNG","LPG","ICE")) return(c)
     if (c == "OTHERS") return("Other")
     paste0(toupper(substr(c, 1, 1)), tolower(substr(c, 2, nchar(c))))

--- a/R/plots.R
+++ b/R/plots.R
@@ -17,6 +17,7 @@ TTM_FUEL_COLORS <- c(
   PHEV     = "#00bdfe",
   EREV     = "#1976d2",
   HEV      = "#ffd300",
+  Hybrid   = "#ffd300",   # combined PHEV+HEV+MHEV bucket (see compute_ttm_long)
   MHEV     = "#c4a000",
   ICE      = "#692500",
   Petrol   = "#502900",

--- a/footnotes.csv
+++ b/footnotes.csv
@@ -1,2 +1,5 @@
 country,variant,footnote
 Canada,Whole,Pre-2017 figures are passenger cars only; SUVs/crossovers included from 2017 (EU M1).
+Türkiye,Whole,Source reports a single combined hybrid figure (no PHEV/HEV split): shown as 'Hybrid' in the fuel-split chart; counted within ICE in the BEV/ICE/PHEV trajectory.
+Georgia,Whole,Source reports a single combined hybrid figure (no PHEV/HEV split): shown as 'Hybrid' in the fuel-split chart; counted within ICE in the BEV/ICE/PHEV trajectory.
+Colombia,Whole,Source reports a single combined hybrid figure (no PHEV/HEV split): shown as 'Hybrid' in the fuel-split chart; counted within ICE in the BEV/ICE/PHEV trajectory.


### PR DESCRIPTION
## What
Colombia, Türkiye and Georgia report a single **combined hybrid figure** (no PHEV/HEV split), which the pipeline parks in the `HEV` column. The TTM market-split chart labelled that band **"HEV"** — misleading, since it's all hybrids combined. (`post_text.R` already labelled this case "Hybrid"; the charts did not.)

## Changes (14 lines)
- **R/data.R** — `compute_ttm_long` relabels `HEV` → `Hybrid` when HEV is the *only* hybrid column with data (no PHEV/EREV/MHEV). Data-driven, no hardcoded country list.
- **R/plots.R** — add `Hybrid` colour (same yellow as HEV) so only the legend label changes, not the band colour.
- **footnotes.csv** — clarify for CO/TR/GE that the source reports one combined hybrid figure (shown as "Hybrid" in the split chart; counted within ICE in the BEV/ICE/PHEV trajectory).

## Verification
- Ran `compute_ttm_long` across all countries: only **Colombia / Türkiye / Georgia** get "Hybrid"; 46 countries with a real PHEV+HEV split keep "HEV".
- Isolated re-render confirms the TTM legend now reads "Hybrid"; the footnote renders correctly.

## Follow-up
Charts go live after re-rendering the three countries via `render-country.yml` (CI commits PNGs + params/weights + manifest).

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)
