### PR TITLE
China: fix May-2026 BEV (42.2%), make the retail-split OCR work, and stop EREV leaking into ICE

### DIFF
--- a/.github/workflows/fetch-china.yml
+++ b/.github/workflows/fetch-china.yml
@@ -55,12 +55,13 @@ jobs:
 
       - name: Install system OCR tools
         # tesseract reads the embedded NEV-market slide JPG for the direct
-        # retail BEV/PHEV/EREV split (the article narrative has only the
-        # NEV aggregate). The eng pack is enough — the table data is Latin
-        # digits; Chinese headers aren't needed for parsing.
+        # retail BEV/PHEV/EREV split (the article narrative has only the NEV
+        # aggregate). The Simplified-Chinese pack (chi_sim) is required: pure
+        # eng mis-segments the teal-banded table and garbles the digits — the
+        # Chinese model anchors the table so the numbers read cleanly.
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends tesseract-ocr
+          sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-chi-sim
 
       - name: Install Python dependencies
         run: pip install requests beautifulsoup4 Pillow

--- a/R/post_text.R
+++ b/R/post_text.R
@@ -95,15 +95,28 @@
   # Second-line: prefer PHEV if reported (column exists and value > 0).
   # If PHEV is missing/zero AND HEV is present, treat HEV as the country's
   # single "Hybrid" total and label accordingly (no parens).
-  use_phev   <- !is.na(phev) && is.finite(phev) && phev > 0
+  bev0  <- if (is.na(bev) || !is.finite(bev)) 0 else bev
+  phev0 <- if (is.na(phev) || !is.finite(phev)) 0 else phev
+  erev0 <- if (is.na(erev) || !is.finite(erev)) 0 else erev
+
+  # EREV is a special case of PHEV (a range-extender is a plug-in hybrid), so
+  # the reported PHEV is the BROAD figure = narrow PHEV column + EREV column,
+  # annotated "(of which X%p were EREV)". This mirrors the (phev + erev) rollup
+  # in R/data.R that drives the BEV/PHEV/ICE plot, and keeps EREV OUT of the ICE
+  # remainder. Almost everywhere EREV is 0 (only China breaks it out), so
+  # phev_broad == phev and nothing changes; for China it moves the EREV share
+  # from the ICE band into PHEV where it belongs.
+  phev_broad <- phev0 + erev0
+
+  use_phev   <- phev_broad > 0
   use_hybrid <- !use_phev && !is.na(hev) && is.finite(hev) && hev > 0
 
-  bev_line <- sprintf("%s BEV", .pt_pct(if (is.na(bev)) 0 else bev))
+  bev_line <- sprintf("%s BEV", .pt_pct(bev0))
 
   if (use_phev) {
-    second_line <- .pt_pp_if("PHEV", phev, "EREV", erev)
-    # ICE = remainder after BEV + PHEV; HEV (if present) goes in parens.
-    ice <- max(0, 1 - (if (is.na(bev)) 0 else bev) - phev)
+    second_line <- .pt_pp_if("PHEV", phev_broad, "EREV", erev)
+    # ICE = remainder after BEV + broad PHEV; HEV (if present) goes in parens.
+    ice <- max(0, 1 - bev0 - phev_broad)
     ice_line <- .pt_pp_if("ICE", ice, "HEV", hev)
   } else if (use_hybrid) {
     second_line <- sprintf("%s Hybrid", .pt_pct(hev))

--- a/data/China.csv
+++ b/data/China.csv
@@ -195,4 +195,4 @@ period,time_interval,variant,source,BEV,PHEV,EREV,OTHERS,ICE,TOTAL,notes
 2026-02,monthly,Whole,CPCA (PHEV excludes EREV from 2025-01-01 onwards if not specified differently),278000.0,134000.0,52000.0,0.0,570000.0,1034000.0,https://www.cpcaauto.com/newslist.php?types=csjd&id=4151
 2026-03,monthly,Whole,CPCA (PHEV excludes EREV from 2025-01-01 onwards if not specified differently),568000.0,204000.0,76000.0,0.0,800000.0,1648000.0,https://www.cpcaauto.com/newslist.php?types=csjd&id=4179
 2026-04,monthly,Whole,CPCA (PHEV excludes EREV from 2025-01-01 onwards if not specified differently),579000.0,192000.0,79000.0,0.0,530000.0,1384000.0,https://www.cpcaauto.com/newslist.php?types=csjd&id=4207
-2026-05,monthly,Whole,CPCA (PHEV excludes EREV from 2025-01-01 onwards if not specified differently) [BEV/PHEV/EREV: ws-proportional],622099.0391722099,261197.33924611972,66703.62158167036,0.0,560000.0,1510000.0,https://www.cpcaauto.com/newslist.php?types=csjd&id=4235
+2026-05,monthly,Whole,CPCA (PHEV excludes EREV from 2025-01-01 onwards if not specified differently),637000.0,228000.0,85000.0,0.0,560000.0,1510000.0,https://www.cpcaauto.com/newslist.php?types=csjd&id=4235

--- a/docs/architecture/24-source-china.md
+++ b/docs/architecture/24-source-china.md
@@ -141,41 +141,53 @@ To re-pull a specific month once OCR is fixed/CPCA republished:
 `fetch_china.py --force --id <NNNN>` (or via the workflow's `workflow_dispatch`
 inputs `detail_id` + `force`).
 
-## 5. Rendering & the post % bands (known quirk)
+## 5. Rendering & the post % bands (EREV ⊆ PHEV)
 
 `render-country.yml` → `R/render_country.R China Whole` fits the Weibull model,
 updates the `China` rows in `params.csv` + `weights.csv`, writes four PNGs under
 `images/<period>/`, and generates `posts/china.txt` (+ periodised
 `posts/china_<period>.txt`).
 
-The post's three bands are computed in `R/post_text.R`
-(`.pt_triplet_lines`), **not** as naive column/TOTAL ratios:
+EREV is a **special case of PHEV** (a range-extender is a plug-in hybrid),
+exactly as HEV is a special case of ICE. The CSV stores EREV in its **own
+additive column** — `BEV + PHEV(narrow) + EREV + ICE = TOTAL`, and the China
+source label notes "PHEV excludes EREV from 2025-01" — so anything that reports
+a PHEV figure must **add EREV back in** to get the broad PHEV. The canonical
+rollup lives in `R/data.R` (drives the BEV/PHEV/ICE plot):
+
+```r
+phev_share <- (phev + erev) / total              # EREV folded into PHEV
+ice_share  <- (total - bev - phev - erev) / total  # EREV kept OUT of ICE
+```
+
+The post bands (`R/post_text.R` `.pt_triplet_lines`) follow the same rule:
 
 ```
-bev  = BEV  / TOTAL
-phev = PHEV / TOTAL            # narrow PHEV column (excludes EREV)
-ice  = 1 - bev - phev         # EREV is NOT subtracted here
-line2 = "<phev>% PHEV (of which <erev>%p were EREV)"
+bev        = BEV / TOTAL
+phev_broad = (PHEV + EREV) / TOTAL
+ice        = 1 - bev - phev_broad
+line2      = "<phev_broad>% PHEV (of which <EREV/TOTAL>%p were EREV)"
 ```
 
-**Quirk worth knowing:** because EREV is its own CSV column (PHEV excludes it
-from 2025-01) but `post_text.R` only subtracts BEV and *narrow* PHEV, the EREV
-share is implicitly folded into the displayed **"ICE"** remainder — while also
-being annotated on the PHEV line. So the post's `ICE %` is **higher** than the
-CSV's `ICE/TOTAL`. Worked example with the corrected May 2026 row
-(BEV 637k, PHEV 228k, EREV 85k, ICE 560k, TOTAL 1,510k):
+So the corrected May 2026 row (BEV 637k, PHEV 228k, EREV 85k, ICE 560k,
+TOTAL 1,510k) renders as:
 
-| | CSV column / TOTAL | Post band |
-|---|---|---|
-| BEV | 42.2 % | **42.2 % BEV** |
-| PHEV (narrow) | 15.1 % | **15.1 % PHEV** (of which 5.6 %p EREV) |
-| EREV | 5.6 % | *(folded into ICE)* |
-| ICE | 37.1 % | **42.7 % ICE** (= 100 − 42.2 − 15.1) |
+```
+42.2% BEV
+20.7% PHEV (of which 5.6%p were EREV)
+37.1% ICE
+```
 
-This is a **downstream rendering convention**, independent of the fetch
-pipeline — flagged here so a future `41.5% ICE`-vs-`37% ICE` head-scratch
-resolves fast. (The stale on-disk `posts/china_2026-05.txt` still shows the
-*old* 41.2 % BEV numbers; it refreshes on the next render — see §7.)
+— bands sum to 100 %, and the post `ICE %` equals the CSV `ICE/TOTAL` (37.1 %).
+
+> **History / regression note.** Before the May-2026 fix, `post_text.R` used the
+> *narrow* PHEV column and `ice = 1 - bev - phev`, which silently left the EREV
+> share inside the displayed **ICE** band (e.g. the stale on-disk
+> `posts/china_2026-05.txt` shows `17.3% PHEV` + `41.5% ICE` instead of
+> `21.7% PHEV` + `37.1% ICE`). EREV is non-zero **only for China**, so this bug
+> was China-only; every other country has `EREV = 0`, where `phev_broad == phev`
+> and nothing changes. Fixed alongside the OCR work. The stale post refreshes on
+> the next render — see §7.
 
 ## 6. Postmortem — the May 2026 "42.2 % BEV" incident
 
@@ -220,7 +232,9 @@ relative to wholesale is the tell to check the fetch log.
 - **Silent fallback.** "Nothing to commit" on a forced re-run does **not** by
   itself prove OCR worked — `preserve_split` keeps a good row stable even when
   the run fell back. Confirm via the `OCR matched …` log line. (§4, §6)
-- **Post ICE % ≠ CSV ICE %** by the EREV share, by rendering design. (§5)
+- **EREV ⊆ PHEV in the post.** The PHEV band is the broad figure (narrow PHEV +
+  EREV); EREV must never leak into the ICE band. This was a China-only bug until
+  the May-2026 fix — guard it if you touch `R/post_text.R`. (§5)
 - **Schedule/manifest noise.** Dispatching `fetch-china.yml` on a feature
   branch can trigger downstream workflows that auto-commit `schedule.ics` /
   `schedule*.html` (`build-manifest.yml`). Those don't belong in a China PR —

--- a/docs/architecture/24-source-china.md
+++ b/docs/architecture/24-source-china.md
@@ -1,0 +1,227 @@
+# 24 · Source: China (CPCA)
+
+CPCA (*全国乘用车市场信息联席会*, the China Passenger Car Association) publishes a
+monthly **market analysis** ("【月度分析】YYYY年M月份全国乘用车市场分析") on
+`cpcaauto.com`. Each month's article reports **two tracks** — retail (零售) and
+wholesale (批发) — in narrative `XXX.X万辆` form, plus a slide deck. The headline
+retail BEV/PHEV/EREV split is **only available as an image** in that deck, which
+makes China the one source in this project that depends on **OCR**. CPCA
+publishes the previous month roughly between the **8th and 11th**.
+
+This playbook is the "what actually happens with China" reference. Low-level
+parsing details live in the `scripts/fetch_china.py` module docstring; this
+file covers the shape, the gotchas, and the incident history so the next dev
+(or LLM) doesn't have to re-derive any of it.
+
+## TL;DR
+
+```
+Source:    CPCA monthly analysis article + slide deck
+           https://www.cpcaauto.com/newslist.php?types=csjd&id=<id>
+Auth:      None, but the host 403s bare requests → desktop User-Agent + a
+           Referer of https://www.cpcaauto.com/ are required.
+API:       None. Scrape the listing for "YYYY年M月份全国乘用车市场分析", follow to
+           the detail page (?id=NNNN, a rotating CPCA-internal id), parse the
+           narrative for TOTAL/NEV/ICE, and OCR a slide for the retail split.
+Tracks:    Retail (零售)    → data/China.csv,          variant="Whole"
+           Wholesale (批发) → data/China_Wholesale.csv, variant="Wholesale"
+Units:     Article is in 万辆 (1万 = 10,000). CSVs store ABSOLUTE units.
+Retail
+ split:    CPCA does NOT print the retail BEV/PHEV/EREV breakdown in text —
+           only the NEV aggregate. The split comes from OCR of the
+           "新能源市场 … 零售、出口分析表" slide (tesseract -l chi_sim+eng).
+Fallback:  If OCR can't read the slide, the split is approximated by applying
+           the WHOLESALE BEV/PHEV/EREV mix to the retail NEV total
+           ("ws-proportional"). This is a proxy and is systematically wrong
+           (see §6). It is tagged in the row's `source` and is preserved-over,
+           never overwritten, once a real value is in the CSV.
+EREV:      Own column. From 2025-01 the narrow PHEV column EXCLUDES EREV
+           (see the source-label suffix). OTHERS is always 0.
+Schedule:  Daily cron 11:00 UTC, 1st→EOM; self-throttles via latest period
+           already in each CSV (no-op until CPCA publishes).
+Scripts:   scripts/fetch_china.py
+Workflow:  .github/workflows/fetch-china.yml  (installs tesseract-ocr +
+           tesseract-ocr-chi-sim)  → render-country.yml (Whole only)
+```
+
+## 1. Two metric tracks, two CSVs
+
+CPCA reports both tracks in the same article:
+
+- **Retail (零售)** — vehicles reaching end consumers in mainland China during
+  the month (≈ registrations). This is the headline series →
+  `data/China.csv`, `variant="Whole"`.
+- **Wholesale (批发)** — manufacturer shipments to dealers, **including exports
+  and inventory build-up**, so it runs 20–40 % higher than retail →
+  `data/China_Wholesale.csv`, `variant="Wholesale"`.
+
+Both CSVs share the canonical column set
+(`period,time_interval,variant,source,BEV,PHEV,EREV,OTHERS,ICE,TOTAL,notes`) and
+are upserted in the **same** `fetch_china.py` run. Only **Whole (retail)** is
+auto-rendered (`render-country.yml`); wholesale is captured for a separate
+downstream model and is **not** rendered yet.
+
+> Naming trap: the retail file's variant is `"Whole"` (as in "whole market"),
+> *not* "wholesale". Wholesale lives in the `_Wholesale.csv` file. Confusing
+> these is the single easiest mistake to make here.
+
+## 2. What is parsed from text vs. from the image
+
+| Field | Retail | Wholesale |
+|---|---|---|
+| TOTAL | narrative (`全国乘用车市场零售 X万辆`) | narrative (`乘用车厂商批发 X万辆`) |
+| NEV aggregate | narrative (`新能源乘用车零售 Y万辆`) | narrative |
+| ICE | narrative, or TOTAL − NEV | narrative, or TOTAL − NEV |
+| **BEV / PHEV / EREV** | **OCR of the NEV slide** (or fallback) | **narrative** (`纯电动批发`, `狭义插混`, `增程式批发`) |
+
+So **wholesale BEV/PHEV/EREV is read straight from the article text** and is
+reliable. The retail split is the only OCR-dependent value, because CPCA never
+restates it in prose.
+
+## 3. The retail-split OCR pipeline
+
+The detail page embeds ~10 JPG slides (`admin/ewebeditor/uploadfile/*.jpg`).
+One — usually deck page 6, titled `新能源市场-YYYY年M月零售、出口分析表` — is a
+table with explicit retail and export breakdowns by fuel:
+
+```
+零售            BEV    PHEV   EREV   NEV          出口   BEV   PHEV  EREV  NEV
+5月份           63.7   22.8   8.5    95.0         5月份  25.2  15.4  12.3  42.4
+4月份           57.8   19.1   7.6    84.5         …
+```
+
+`fetch_china.py` downloads each slide and OCRs it until one row reconciles
+against the article's retail NEV total. The important, hard-won details:
+
+- **Language matters more than resolution.** Pure `tesseract -l eng`
+  mis-segments this teal-banded table and **garbles the digit cells** — May
+  2026's `63.7 / 22.8 / 8.5 / 95.0` came out as `3 45 55.6 7`. Loading the
+  Simplified-Chinese model (`-l chi_sim+eng`) anchors the table structure and
+  the numbers read cleanly. **This is why the workflow installs
+  `tesseract-ocr-chi-sim`.**
+- **Self-validating config ladder.** `OCR_CONFIGS` lists
+  `(scale, lang)` pairs tried in order — `6x chi_sim+eng` first, then 5x/4x,
+  then a legacy `4x eng`. For each slide we try each config until
+  `_extract_retail_from_ocr` returns a row whose `BEV+PHEV+EREV ≈ NEV` **and**
+  `NEV ≈ the article's retail NEV total` (`_recover_decimal`). A wrong config
+  simply fails that cross-check, so trying several is safe — we can never
+  silently accept a misread table (e.g. the wholesale one).
+- **Decimal recovery.** OCR sometimes drops the decimal point (`57.9` → `579`)
+  or splits it into two tokens (`37` `8`). `_recover_decimal` /
+  `_merge_split_decimals` reconstruct it by enforcing the NEV sum.
+- **Diagnostic logging.** When a month-label line matches but the tokens don't
+  reconcile, the run prints `DEBUG OCR: …` lines, and a clean hit logs
+  `OCR matched <file> [<config>] … BEV=.. PHEV=.. EREV=.. NEV=..`. If you ever
+  need to know why a month went to the fallback, read the
+  "Fetch & update China CSVs" step log.
+
+## 4. The ws-proportional fallback (and how to override by hand)
+
+If **no** slide/config reconciles, `build_rows` derives the retail split by
+applying the wholesale mix to the retail NEV total:
+
+```
+retail_bev = retail_nev * ws_bev  / (ws_bev + ws_phev + ws_erev)
+retail_phev = …  ; retail_erev = …
+```
+
+Such a row is tagged `source = "CPCA (…) [BEV/PHEV/EREV: ws-proportional]"`.
+This is a **proxy**, not the truth (§6 shows how far off it can be). Two
+safety rails exist:
+
+- **`preserve_split`** (in `upsert_csv`): a ws-proportional run will **not**
+  overwrite an existing row that already has BEV/PHEV/EREV filled in. So a
+  good value (OCR or hand-entered) is never clobbered by a later proxy run.
+- **Manual override.** To correct a month by hand: read the four retail
+  numbers off the CPCA NEV slide (万), multiply by 10,000, and edit
+  `data/China.csv`, dropping the `[ws-proportional]` suffix from `source`.
+  `preserve_split` then protects your values on subsequent runs.
+
+To re-pull a specific month once OCR is fixed/CPCA republished:
+`fetch_china.py --force --id <NNNN>` (or via the workflow's `workflow_dispatch`
+inputs `detail_id` + `force`).
+
+## 5. Rendering & the post % bands (known quirk)
+
+`render-country.yml` → `R/render_country.R China Whole` fits the Weibull model,
+updates the `China` rows in `params.csv` + `weights.csv`, writes four PNGs under
+`images/<period>/`, and generates `posts/china.txt` (+ periodised
+`posts/china_<period>.txt`).
+
+The post's three bands are computed in `R/post_text.R`
+(`.pt_triplet_lines`), **not** as naive column/TOTAL ratios:
+
+```
+bev  = BEV  / TOTAL
+phev = PHEV / TOTAL            # narrow PHEV column (excludes EREV)
+ice  = 1 - bev - phev         # EREV is NOT subtracted here
+line2 = "<phev>% PHEV (of which <erev>%p were EREV)"
+```
+
+**Quirk worth knowing:** because EREV is its own CSV column (PHEV excludes it
+from 2025-01) but `post_text.R` only subtracts BEV and *narrow* PHEV, the EREV
+share is implicitly folded into the displayed **"ICE"** remainder — while also
+being annotated on the PHEV line. So the post's `ICE %` is **higher** than the
+CSV's `ICE/TOTAL`. Worked example with the corrected May 2026 row
+(BEV 637k, PHEV 228k, EREV 85k, ICE 560k, TOTAL 1,510k):
+
+| | CSV column / TOTAL | Post band |
+|---|---|---|
+| BEV | 42.2 % | **42.2 % BEV** |
+| PHEV (narrow) | 15.1 % | **15.1 % PHEV** (of which 5.6 %p EREV) |
+| EREV | 5.6 % | *(folded into ICE)* |
+| ICE | 37.1 % | **42.7 % ICE** (= 100 − 42.2 − 15.1) |
+
+This is a **downstream rendering convention**, independent of the fetch
+pipeline — flagged here so a future `41.5% ICE`-vs-`37% ICE` head-scratch
+resolves fast. (The stale on-disk `posts/china_2026-05.txt` still shows the
+*old* 41.2 % BEV numbers; it refreshes on the next render — see §7.)
+
+## 6. Postmortem — the May 2026 "42.2 % BEV" incident
+
+**Symptom.** A user reported China May-2026 at **42.2 % BEV**; the gallery
+showed **41.2 %**.
+
+**Cause.** The scheduled fetch ran on a runner where the retail-slide OCR
+failed (`tesseract -l eng` garbled the digits to `3 45 55.6 7`, which the NEV
+cross-check correctly rejected), so the row silently fell back to
+**ws-proportional**. The wholesale mix is not the retail mix, so *all three*
+NEV columns were off:
+
+| | ws-proportional (wrong) | CPCA slide (correct) | Δ |
+|---|---|---|---|
+| BEV | 622,099 | **637,000** | +14,901 (41.2 % → **42.2 %**) |
+| PHEV | 261,197 | **228,000** | −33,197 |
+| EREV | 66,704 | **85,000** | +18,296 |
+
+(Wholesale for May was correct — read from text: BEV 886k / PHEV 372k / EREV
+95k.)
+
+**Fix.** (1) Corrected the May retail row by hand from the official slide
+(63.7 / 22.8 / 8.5 / 95.0 万). (2) Root-caused the OCR and switched it to
+`chi_sim+eng` with a self-validating config ladder, so the split is **read**,
+not proxied, going forward. Verified end-to-end on a live runner:
+`OCR matched … [6x chi_sim+eng] … BEV=63.7 PHEV=22.8 EREV=8.5 NEV=95.0`.
+
+**Lesson.** The ws-proportional fallback was failing **silently** — the only
+trace was a single `WARNING … falling back` line nobody reads. It is now far
+more visible via the `DEBUG OCR` lines, and OCR is reliable, but the fallback
+still exists as a last resort, so a sudden China BEV that looks "smooth"
+relative to wholesale is the tell to check the fetch log.
+
+## 7. Gotchas
+
+- **`variant="Whole"` is retail**, not wholesale. (§1)
+- **OCR needs `chi_sim`.** Without the `tesseract-ocr-chi-sim` apt package the
+  retail split silently degrades to the ws-proportional proxy. (§3)
+- **Rotating detail ids.** `?id=NNNN` is CPCA-internal and sequential; never
+  hard-code it — discover it from the listing, or pass `--id` for a backfill.
+- **403 on bare requests.** A desktop `User-Agent` + `Referer` are mandatory.
+- **Silent fallback.** "Nothing to commit" on a forced re-run does **not** by
+  itself prove OCR worked — `preserve_split` keeps a good row stable even when
+  the run fell back. Confirm via the `OCR matched …` log line. (§4, §6)
+- **Post ICE % ≠ CSV ICE %** by the EREV share, by rendering design. (§5)
+- **Schedule/manifest noise.** Dispatching `fetch-china.yml` on a feature
+  branch can trigger downstream workflows that auto-commit `schedule.ics` /
+  `schedule*.html` (`build-manifest.yml`). Those don't belong in a China PR —
+  drop them before merging.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -35,6 +35,7 @@ It is **not** a tutorial. It documents what exists, why it was built that way, a
 | 21 | [21-source-luxembourg.md](21-source-luxembourg.md) | Per-country source playbook for Luxembourg (lustat.statec.lu SDMX, dataflow DF_D6122). Clean SDMX-CSV; Whole/Vans/HDV variants. Template for other .Stat Suite sources. |
 | 22 | [22-source-poland.md](22-source-poland.md) | Per-country source playbook for Poland (PZPM eRegistrations XLSX from CEP). Page-scraped workbook, "Ogółem" sheet only; Whole/Vans/HDV/Buses; OTHERS residual. Takes Poland over from ACEA. |
 | 23 | [23-source-malaysia.md](23-source-malaysia.md) | Per-country source playbook for Malaysia (data.gov.my parquet, individual registration events, combined hybrid bucket). |
+| 24 | [24-source-china.md](24-source-china.md) | Per-country source playbook for China (CPCA monthly analysis). The only **OCR-dependent** source: the retail BEV/PHEV/EREV split is read from a slide image via `tesseract -l chi_sim+eng`, with a ws-proportional fallback. Includes the May-2026 mis-OCR postmortem and the post-band ICE% quirk. |
 
 ## Big picture in one diagram
 

--- a/scripts/fetch_china.py
+++ b/scripts/fetch_china.py
@@ -3,6 +3,10 @@
 Fetch China vehicle sales data from CPCA and update data/China.csv plus
 data/China_Wholesale.csv.
 
+See docs/architecture/24-source-china.md for the high-level playbook (tracks,
+the OCR pipeline, the ws-proportional fallback, manual overrides, and the
+May-2026 mis-OCR postmortem). This docstring covers the low-level parsing.
+
 Usage
 -----
     python scripts/fetch_china.py [--year YEAR] [--month MONTH] \\

--- a/scripts/fetch_china.py
+++ b/scripts/fetch_china.py
@@ -217,10 +217,14 @@ def _grab(pat: re.Pattern, text: str) -> float | None:
 # DOES NOT restate the retail BEV/PHEV/EREV split, so this table is our only
 # direct source for those values.
 #
-# We OCR each candidate image (with `tesseract -l eng`) — the column headers
-# and data are Latin/numeric, so the Chinese language pack is not required.
-# Decimal points are sometimes dropped by OCR ("57.9" → "579"); we recover
-# them by enforcing BEV+PHEV+EREV ≈ NEV on the matched row.
+# We OCR each candidate image with the Simplified-Chinese model
+# (`tesseract -l chi_sim+eng`) at a 6× upscale: although the data cells are
+# Latin/numeric, pure `-l eng` mis-segments this teal-banded table and garbles
+# the digits (63.7/22.8/8.5/95.0 → "3 45 55.6 7"). The Chinese model anchors
+# the table structure so the numbers come out clean. See OCR_CONFIGS for the
+# full retry ladder. Decimal points are sometimes dropped by OCR ("57.9" →
+# "579"); we recover them by enforcing BEV+PHEV+EREV ≈ NEV on the matched row,
+# which also validates that a given OCR config read the right table.
 # ----------------------------------------------------------------------
 
 def _have_tesseract() -> bool:
@@ -243,18 +247,36 @@ def collect_image_urls(html: str, base_url: str | None = None) -> list[str]:
     return urls
 
 
-def _ocr_image_bytes(jpg_bytes: bytes) -> str:
+# OCR configs tried (in order) per slide image until the retail row validates
+# against the article NEV total. CPCA's NEV-market table is a teal-banded
+# 960×540 JPEG; pure `eng` mis-segments the digit cells and garbles the row
+# (e.g. 63.7/22.8/8.5/95.0 → "3 45 55.6 7"). Loading the Simplified-Chinese
+# model (chi_sim+eng) lets tesseract segment the table correctly, and a 6×
+# upscale gives the small digits enough resolution. We keep 4× chi_sim and the
+# legacy 4× eng as cheaper fallbacks; the NEV cross-check rejects any config
+# whose output doesn't reconcile, so trying several is safe.
+OCR_CONFIGS = [
+    (6, "chi_sim+eng"),
+    (5, "chi_sim+eng"),
+    (4, "chi_sim+eng"),
+    (4, "eng"),
+]
+
+
+def _ocr_image_bytes(jpg_bytes: bytes, scale: int = 6, lang: str = "chi_sim+eng") -> str:
     """Run tesseract on a JPG byte string and return the OCR text.
 
-    The image is 4× upscaled before OCR; CPCA's slides are 960×540 JPEGs
-    and the small digits OCR much more cleanly at 4×.
+    `scale` upsamples the 960×540 slide before OCR (small digits read far more
+    reliably enlarged); `lang` selects the tesseract model(s). Defaults match
+    OCR_CONFIGS[0] — the configuration that reads CPCA's NEV table cleanly.
+    Returns "" if the requested language pack is missing or tesseract fails.
     """
     from PIL import Image  # lazy import — only needed when OCR runs
     from io import BytesIO
 
     with tempfile.TemporaryDirectory() as tmp:
         img = Image.open(BytesIO(jpg_bytes))
-        big = img.resize((img.width * 4, img.height * 4), Image.LANCZOS)
+        big = img.resize((img.width * scale, img.height * scale), Image.LANCZOS)
         png_path = Path(tmp) / "page.png"
         out_path = Path(tmp) / "ocr"
         big.save(png_path)
@@ -262,7 +284,7 @@ def _ocr_image_bytes(jpg_bytes: bytes) -> str:
             subprocess.run(
                 [
                     "tesseract", str(png_path), str(out_path),
-                    "-l", "eng", "--psm", "6",
+                    "-l", lang, "--psm", "6",
                     "-c", "preserve_interword_spaces=1",
                 ],
                 check=True,
@@ -392,10 +414,13 @@ def _extract_retail_from_ocr(text: str, month: int, nev_target_wan: float) -> tu
         if len(tokens) >= 5 and tokens[4] == str(month):
             tokens = tokens[:4] + tokens[5:]
         if len(tokens) < 8:
+            print(f"  DEBUG OCR: month label matched but only {len(tokens)} tokens: {tokens}")
             continue
         recovered = _recover_decimal(tokens[:4], nev_target_wan)
-        if recovered is not None:
-            return recovered, line
+        if recovered is None:
+            print(f"  DEBUG OCR: decimal recovery failed — tokens={tokens[:4]}, nev_target={nev_target_wan}")
+            continue
+        return recovered, line
     return None
 
 
@@ -423,22 +448,28 @@ def parse_retail_table(
             resp.raise_for_status()
         except requests.RequestException:
             continue
-        text = _ocr_image_bytes(resp.content)
-        if not text:
-            continue
 
-        # The headers ("BEV PHEV EREV NEV") are rendered as styled white text
-        # on a teal band and survive OCR poorly with -l eng. Skip the header
-        # check; the NEV-target validation in _recover_decimal is sufficient
-        # to reject wrong tables.
-
-        result = _extract_retail_from_ocr(text, month, nev_target_wan)
+        # Try each OCR config until one yields a row that reconciles against
+        # the article NEV total. The headers ("BEV PHEV EREV NEV") are styled
+        # white-on-teal and OCR poorly regardless, so we rely solely on the
+        # NEV cross-check in _recover_decimal to confirm we read the right
+        # table — that also makes trying multiple configs safe.
+        result = None
+        for scale, lang in OCR_CONFIGS:
+            text = _ocr_image_bytes(resp.content, scale=scale, lang=lang)
+            if not text:
+                continue
+            result = _extract_retail_from_ocr(text, month, nev_target_wan)
+            if result is not None:
+                ocr_cfg = f"{scale}x {lang}"
+                break
         if result is None:
             continue
         recovered, line = result
         bev_wan, phev_wan, erev_wan, nev_wan = recovered
         print(
-            f"OCR matched {url.rsplit('/', 1)[-1]} row '{line.strip()[:60]}' → "
+            f"OCR matched {url.rsplit('/', 1)[-1]} [{ocr_cfg}] "
+            f"row '{line.strip()[:60]}' → "
             f"retail BEV={bev_wan} PHEV={phev_wan} EREV={erev_wan} NEV={nev_wan} (万)"
         )
         return {
@@ -764,10 +795,16 @@ def main() -> None:
         if args.image_dir:
             # OCR each local JPG until one matches the article NEV target.
             for path in sorted(Path(args.image_dir).glob("*.jp*g")):
-                text = _ocr_image_bytes(path.read_bytes())
-                if not text:
-                    continue
-                result = _extract_retail_from_ocr(text, target_month, nev_target_wan)
+                img_bytes = path.read_bytes()
+                result = None
+                for scale, lang in OCR_CONFIGS:
+                    text = _ocr_image_bytes(img_bytes, scale=scale, lang=lang)
+                    if not text:
+                        continue
+                    result = _extract_retail_from_ocr(text, target_month, nev_target_wan)
+                    if result is not None:
+                        ocr_cfg = f"{scale}x {lang}"
+                        break
                 if result is None:
                     continue
                 recovered, line = result
@@ -780,7 +817,7 @@ def main() -> None:
                     "source_image": f"file://{path}",
                 }
                 print(
-                    f"OCR matched {path.name} row '{line.strip()[:60]}' → "
+                    f"OCR matched {path.name} [{ocr_cfg}] row '{line.strip()[:60]}' → "
                     f"retail BEV={bev_wan} PHEV={phev_wan} EREV={erev_wan} NEV={nev_wan} (万)"
                 )
                 break


### PR DESCRIPTION
## Why

A user reported China **May 2026 at 42.2 % BEV**; the gallery showed **41.2 %**.

Root cause: CPCA only publishes the retail BEV/PHEV/EREV split as an **image** in
its slide deck. The fetcher OCR'd it with `tesseract -l eng`, which mis-segments
the teal-banded table and garbled the digits (`63.7/22.8/8.5/95.0` → `3 45 55.6 7`).
The NEV cross-check correctly rejected the garbage, so the row **silently fell
back** to the "ws-proportional" proxy (apply the wholesale mix to the retail NEV
total). The wholesale mix isn't the retail mix, so **all three** NEV columns were
off — including BEV (41.2 % instead of 42.2 %).

Investigating the post text then surfaced a **second, separate bug**: EREV was
leaking into the ICE band instead of being counted under PHEV.

## What

**1. Correct the May 2026 retail row** from the official CPCA NEV slide (id=4235):

| | ws-proportional (was) | CPCA slide (now) |
|---|---|---|
| BEV | 622,099 (41.2 %) | **637,000 (42.2 %)** |
| PHEV | 261,197 | **228,000** |
| EREV | 66,704 | **85,000** |

(63.7 / 22.8 / 8.5 / 95.0 万; BEV 637,000 / 1,510,000 = 42.2 %. Wholesale was
already correct — it's read from article text, not OCR.)

**2. Fix the OCR so the split is read, not proxied.** The fix is the **language
model**, not resolution: `chi_sim+eng` anchors the table so the digits read
cleanly.
- `_ocr_image_bytes`: parameterised `scale` + `lang` (default `6x chi_sim+eng`)
- `parse_retail_table` / `--image-dir`: try `OCR_CONFIGS` in order, accept the
  first row that reconciles against the article NEV total — **self-validating**,
  so a wrong config can never be silently accepted
- diagnostic logging for token/decimal-recovery failures
- workflow installs `tesseract-ocr-chi-sim`

**3. Stop EREV leaking into ICE in the post text** (`R/post_text.R`). EREV is a
special case of PHEV (a range-extender is a plug-in hybrid), and the CSV stores
it in its own additive column. The post reported the **narrow** PHEV and computed
`ICE = 1 − BEV − PHEV`, so the EREV share landed in the **ICE** band. The
BEV/PHEV/ICE plot already folds it correctly in `R/data.R` (`(phev + erev)`; ICE
excludes erev); the post now matches:

```
            before                         after
  17.3% PHEV (of which 4.4%p EREV)   →   21.7% PHEV (of which 4.4%p EREV)
  41.5% ICE                          →   37.1% ICE      (= CSV ICE/TOTAL)
```

EREV is non-zero **only for China**, so this is a China-only correction — every
other country has `EREV = 0`, where `phev_broad == phev` and output is unchanged.
(Numbers above use the corrected May data; the re-rendered post will read
`42.2% BEV / 20.7% PHEV (of which 5.6%p EREV) / 37.1% ICE`.)

**4. Document it.** New `docs/architecture/24-source-china.md` — the China source
playbook: retail vs wholesale two-CSV split, what's parsed from text vs OCR'd,
the `chi_sim+eng` self-validating OCR ladder, the ws-proportional fallback +
`preserve_split`/manual-override path, the EREV-⊆-PHEV post convention, and a
postmortem of this incident.

## Verification

OCR fix, end-to-end on a live runner (`fetch-china.yml`, `--force --id 4235`):

```
OCR matched 20260608081336770006.jpg [6x chi_sim+eng]
  row '5月份  63.7  22.8  8.5  95.0 ...' → retail BEV=63.7 PHEV=22.8 EREV=8.5 NEV=95.0 (万)
```

Post fix: bands sum to 100 %, ICE band now equals CSV `ICE/TOTAL` (37.1 %).

## Notes for the reviewer

- **`variant="Whole"` is retail**, not wholesale (wholesale is the `_Wholesale.csv`).
- The **ws-proportional fallback still exists** as a last resort, but is now
  visible in logs and OCR is reliable.
- After merge, the **May post + gallery PNGs re-render** via `render-country.yml`;
  the on-disk `posts/china_2026-05.txt` still shows the old numbers until then.
- The EREV→PHEV change in `R/post_text.R` is generic but **only affects China**
  (the sole source with a non-zero EREV column); all other posts are byte-identical.

🤖 https://claude.ai/code/session_01AJcDLt52PRhHGWNMuWopqB