### PR TITLE
fix(poland): retry transient timeouts against slow PZPM server

### DIFF
--- a/scripts/fetch_poland.py
+++ b/scripts/fetch_poland.py
@@ -68,6 +68,8 @@ from pathlib import Path
 
 import openpyxl
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 PAGE_URL = "https://www.pzpm.org.pl/en/Electromobility/eRegistrations"
 HOST = "https://www.pzpm.org.pl"
@@ -110,7 +112,7 @@ def fold(s: str) -> str:
 
 def find_xlsx(session: requests.Session) -> tuple[str, str]:
     """Scrape the eRegistrations page -> (absolute xlsx url, period 'YYYY-MM')."""
-    r = session.get(PAGE_URL, timeout=30)
+    r = session.get(PAGE_URL, timeout=60)
     r.raise_for_status()
     m = re.search(r'href="([^"]*tabele[^"]*\.xlsx)"', r.text, re.IGNORECASE)
     if not m:
@@ -252,6 +254,11 @@ def main() -> None:
     else:
         session = requests.Session()
         session.headers.update({"User-Agent": UA})
+        _retry = Retry(total=4, read=4, connect=4, backoff_factor=2,
+                       status_forcelist=[500, 502, 503, 504], raise_on_status=False)
+        _adapter = HTTPAdapter(max_retries=_retry)
+        session.mount("https://", _adapter)
+        session.mount("http://", _adapter)
         url, period = find_xlsx(session)
         print(f"Latest PZPM workbook: {period}  ({url})")
         if not args.force:


### PR DESCRIPTION
## Problem

Der Poland-Fetch-Workflow ist mit einem `ReadTimeout` gegen `www.pzpm.org.pl` abgebrochen:

```
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='www.pzpm.org.pl', port=443):
Read timed out. (read timeout=30)
```

`find_xlsx()` hat die eRegistrations-Seite mit einem festen 30s-Timeout und **ohne Retries** geladen. Ein einzelner langsamer Antwortzeitpunkt des PZPM-Servers ließ damit den ganzen Job fehlschlagen.

## Fix

- **Retry-Adapter** auf die `requests.Session` gemountet (`urllib3.Retry`, `total=4`, exponentielles Backoff mit `backoff_factor=2`, plus 5xx im `status_forcelist`). Transiente Read-/Connect-Timeouts werden jetzt automatisch wiederholt statt den Workflow abzubrechen. Profitiert auch `download_xlsx()`, da es dieselbe Session nutzt.
- **Page-Fetch-Timeout** von 30s → 60s, damit ein langsam startender Response nicht sofort als Fehler zählt.

Das Muster ist identisch zu `fetch_austria.py`, `fetch_luxembourg.py` und `fetch_netherlands.py` (`Retry` + `HTTPAdapter` + `session.mount(...)`), also repo-konform.

## Test

- Syntax-Check des Skripts ist sauber.
- Reine Netzwerk-Robustheit; Parsing-Logik unverändert.

https://claude.ai/code/session_019tCBnFVxTgCXNPndw7NVzA

---
_Generated by [Claude Code](https://claude.ai/code/session_019tCBnFVxTgCXNPndw7NVzA)_