### PR TITLE
fix(tags): blank ttm_bev_share wrongly flagged countries as no-transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -3700,8 +3700,12 @@ function getT0Years(r){ const baseDate=r.baseline_date||'', baseYear=normNumber(
 const MIN_TRANSITION_SLOPE = 0.01;
 // Full row-level check — use this everywhere a params row is available.
 function rowHasNoTransition(r){
-  const ttmBev = normNumber(r.ttm_bev_share);
-  if (isFinite(ttmBev) && ttmBev < 0.01) return true;
+  // Treat empty/missing ttm_bev_share as unknown (NaN), not 0.
+  // normNumber('') returns 0 which would wrongly trigger the <1% check.
+  const ttmRaw = String(r.ttm_bev_share ?? '').trim();
+  const ttmBev = ttmRaw !== '' ? Number(ttmRaw.replace(',', '.')) : NaN;
+  if (isFinite(ttmBev) && ttmBev < 0.01) return true;   // < 1% BEV → clearly no transition
+  if (isFinite(ttmBev) && ttmBev >= 0.05) return false;  // ≥ 5% BEV → clearly in transition
   const v1n = normNumber(r.v1), v2n = normNumber(r.v2);
   if(!isFinite(v1n) || !isFinite(v2n)) return true;
   if(v1n >= 0) return true;


### PR DESCRIPTION
## Summary

- `normNumber('')` returns `0` (not `NaN`) because `Number('') === 0`
- Every row with a **blank `ttm_bev_share`** hit the `ttmBev < 0.01` guard and was tagged "No transition" — even rows with 5–14 pp/yr inflection slopes
- Affected: **India, Switzerland HDV, Germany Custom, Latvia Used** (and any other row without TTM data)

## Fix

In `rowHasNoTransition()`:
1. Parse `ttm_bev_share` as a raw string; empty/missing → `NaN` → TTM check is skipped, falls through to slope math
2. Positive override: `ttmBev ≥ 5%` → `return false` immediately (clearly in transition) — fixes **Italy Rental** which has 5.46% BEV share but a slope just under the 1 pp/yr threshold

## Test plan

- [ ] India, Switzerland HDV, Germany Custom, Latvia Used no longer show "No transition" tag
- [ ] Italy Rental no longer shows "No transition" tag
- [ ] Rows with genuinely low BEV share (< 1% TTM) still correctly show "No transition"

https://claude.ai/code/session_019tCBnFVxTgCXNPndw7NVzA

---
_Generated by [Claude Code](https://claude.ai/code/session_019tCBnFVxTgCXNPndw7NVzA)_