### PR TITLE
fix(chile): dump PDF text on parse failure to diagnose format change

### DIFF
--- a/scripts/fetch_chile.py
+++ b/scripts/fetch_chile.py
@@ -248,8 +248,17 @@ def parse_emisiones(text: str) -> dict[str, int]:
 
     missing = set(EMISIONES_LABELS.values()) - set(result.keys())
     if missing:
+        # Dump extracted text so CI logs show exactly what changed in the PDF.
+        char_count = len(text)
+        snippet = text[:3000] if char_count > 0 else "(empty — PDF may be image-based)"
+        print(
+            f"\n=== Emisiones PDF text dump ({char_count} chars) ===\n"
+            f"{snippet}\n"
+            f"=== end dump ===\n"
+        )
         raise RuntimeError(
-            f"Could not extract {sorted(missing)} from Cero y Bajas Emisiones PDF"
+            f"Could not extract {sorted(missing)} from Cero y Bajas Emisiones PDF. "
+            f"See text dump above to diagnose format change."
         )
     return result
 


### PR DESCRIPTION
## What failed

Chile fetch failed today (2026-06-18 11:58 UTC) — both PDFs for Mayo 2026 were found and downloaded, but `parse_emisiones()` couldn't extract BEV/HEV/PHEV from the Emisiones PDF:

```
Found Emisiones: …/05-ANAC-Informe-Cero-y-Bajas-Emisiones-Mayo-2026.pdf
Parsed TOTAL: 24449
RuntimeError: Could not extract ['BEV', 'HEV', 'PHEV'] from Cero y Bajas Emisiones PDF
```

All three values missing simultaneously → ANAC likely changed the table layout or the PDF is now image-based for May 2026.

## Fix

Add a 3000-char text dump to CI logs when parsing fails, so the next run reveals exactly what pypdf extracts from the new format. Without this, there's nothing to go on.

## Next step

Merge this, then either re-run the workflow manually or wait for the next scheduled run. The failure output will show the extracted PDF text so the regex can be updated to match the new layout.

https://claude.ai/code/session_019tCBnFVxTgCXNPndw7NVzA

---
_Generated by [Claude Code](https://claude.ai/code/session_019tCBnFVxTgCXNPndw7NVzA)_