### PR TITLE
fix(chile): add May-2026 label variants + wider PDF text dump

### DIFF
--- a/scripts/fetch_chile.py
+++ b/scripts/fetch_chile.py
@@ -115,11 +115,22 @@ SPANISH_MONTHS = {
     9: "Septiembre", 10: "Octubre", 11: "Noviembre", 12: "Diciembre",
 }
 
-# Labels in the emisiones summary table → CSV column
+# Labels in the emisiones summary table → CSV column.
+# ANAC periodically renames rows; list all known variants so the parser
+# survives minor label changes.  The first match per csv_key wins.
 EMISIONES_LABELS = {
+    # Original labels (pre-2026)
     "Eléctricos": "BEV",
     "Híbrido Enchufables": "PHEV",
     "Híbrido Convencional": "HEV",
+    # Variants seen / anticipated from May-2026 report narrative
+    "100% Eléctricos": "BEV",
+    "Eléctrico Puro": "BEV",
+    "Eléctrico": "BEV",
+    "Híbridos Enchufables": "PHEV",
+    "Híbrido Enchufable": "PHEV",
+    "Híbridos Convencionales": "HEV",
+    "Híbrido Convencionales": "HEV",
 }
 
 # Row pattern after stripping the label: <int> <pct>% <int> <pct>%
@@ -248,9 +259,17 @@ def parse_emisiones(text: str) -> dict[str, int]:
 
     missing = set(EMISIONES_LABELS.values()) - set(result.keys())
     if missing:
-        # Dump extracted text so CI logs show exactly what changed in the PDF.
         char_count = len(text)
-        snippet = text[:3000] if char_count > 0 else "(empty — PDF may be image-based)"
+        if char_count == 0:
+            snippet = "(empty — PDF may be image-based)"
+        else:
+            # Dump 4 evenly-spaced windows so CI logs cover the full document.
+            step = max(1, char_count // 4)
+            windows = []
+            for start in [0, step, step * 2, step * 3]:
+                end = min(start + 3000, char_count)
+                windows.append(f"[chars {start}–{end}]:\n{text[start:end]}")
+            snippet = "\n\n".join(windows)
         print(
             f"\n=== Emisiones PDF text dump ({char_count} chars) ===\n"
             f"{snippet}\n"


### PR DESCRIPTION
## Problem

Chile fetch failing since 2026-06-18. The May 2026 "Informe Cero y Bajas Emisiones" PDF has a changed layout — none of the three labels (BEV/HEV/PHEV) are found.

The CI text dump showed the PDF is text-based (39,558 chars) but only the intro narrative was visible in the first 3,000 chars. The narrative uses new label names:
- `100% eléctricos` (was `Eléctricos`)  
- `híbridos enchufables` (was `Híbrido Enchufables`)
- `híbridos convencionales` (was `Híbrido Convencional`)

## Changes

1. **Expanded `EMISIONES_LABELS`** — adds plural/alternative variants observed in the May-2026 narrative so the parser can match the new table row labels without failing
2. **Wider diagnostic dump** — 4 evenly-spaced 3,000-char windows instead of just the first 3,000, covering the full document so we can see the actual table in CI logs if the label fix isn't enough

## Next step

If the label variants fix it → done. If it still fails, the extended dump will show us the exact table text so we can write a precise regex fix.

https://claude.ai/code/session_019tCBnFVxTgCXNPndw7NVzA

---
_Generated by [Claude Code](https://claude.ai/code/session_019tCBnFVxTgCXNPndw7NVzA)_