### PR TITLE
fix(acea): rename dead parse_monthly_table to _parse_via_text

### DIFF
--- a/scripts/fetch_acea.py
+++ b/scripts/fetch_acea.py
@@ -463,31 +463,13 @@ def _parse_cell(s: str) -> tuple[int, int] | None:
     return ints[0], ints[1]
 
 
-def _dump_pdf_diagnostics(pdf) -> None:
-    """Print what pdfplumber sees for every page/table candidate. Called on
-    parser failure so we can iterate on layout changes (e.g. April 2026
-    switched from the old PDF generator to Microsoft Word, which renders
-    table cell boundaries differently)."""
-    print("DIAGNOSTIC: tables pdfplumber found")
-    for pi, page in enumerate(pdf.pages):
-        tables = page.extract_tables() or []
-        print(f"  page {pi}: {len(tables)} table(s)")
-        for ti, cand in enumerate(tables):
-            rows = len(cand) if cand else 0
-            cols = len(cand[0]) if cand and cand[0] else 0
-            print(f"    table {ti}: rows={rows}, cols={cols}")
-            for ri, row in enumerate(cand[:3] if cand else []):
-                preview = " | ".join((c or "").replace("\n", "\\n")[:40] for c in row)
-                print(f"      row[{ri}]: {preview}")
+def _parse_via_text(pdf) -> tuple[dict[str, dict[str, tuple[int, int]]], str | None]:
+    """Text-layer parser for April 2026+ Word-generated PDFs.
 
-
-def parse_monthly_table(pdf_path: str) -> tuple[dict[str, dict[str, tuple[int, int]]], str | None]:
-    """Returns ({country: {fuel: (curr, prev)}}, period_label).
-
-    Works on the April 2026+ Word-generated PDFs where extract_tables()
-    returns nothing on the country pages. Each country renders as a single
-    line carrying 14 integers (7 fuel sections × {current, prior}); we
-    tokenise and read off pairs in the documented PDF column order.
+    extract_tables() returns nothing on these files because the cell
+    boundaries aren't explicit rules. Instead each country renders as a
+    single line carrying 14 integers (7 fuel sections × {current, prior});
+    we tokenise via extract_text() and read off pairs in PDF column order.
     """
     wanted = set(ALL_COUNTRIES)
     for page in pdf.pages:


### PR DESCRIPTION
## Bug

`fetch_acea.py` crashed with `NameError: name '_parse_via_text' is not defined` on every run where the PDF was actually downloaded and parsed.

## Root cause

The text-layer parser (for April 2026+ Word-generated PDFs) was accidentally named `parse_monthly_table` — identical to the outer dispatcher function. Python silently used the second `parse_monthly_table` definition (the dispatcher), making the text-layer parser dead code. When the dispatcher then called `_parse_via_text(pdf)`, the function didn't exist.

Additionally, a shorter duplicate `_dump_pdf_diagnostics` had been inserted between `_parse_cell` and the text-layer parser, overriding the richer version that also dumps per-page text and alternate extract_tables strategies.

## Fix

- Rename the dead `parse_monthly_table` → `_parse_via_text(pdf)` with a correct docstring
- Remove the duplicate (shorter) `_dump_pdf_diagnostics`, restoring the original richer version

The June 19 success run apparently used `_parse_via_tables` (the legacy table parser) which still worked; June 21–22 were "nothing to do" runs since May data was already in the CSVs.

---
_Generated by [Claude Code](https://claude.ai/code/session_019tCBnFVxTgCXNPndw7NVzA)_