### PR TITLE
data: Australia (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/Australia.csv
+++ b/data/Australia.csv
@@ -75,3 +75,4 @@ period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,note
 2026-03,monthly,Whole,VFACTS & Prof. Ray Willis,15839.0,8215.0,17953.0,34694.0,28364.0,,105065.0,
 2026-04,monthly,Whole,VFACTS & Prof. Ray Willis,15459,9628,18162,25399,22414,,91062,Check again for consistency
 2026-05,monthly,Whole,VFACTS & Prof. Ray Willis,21303,9315,19024,28692,25191,,103525,
+2026-06,monthly,Whole,KBA,84057,32212,83315,60796,33862,2136,296378,https://www.kba.de/DE/Presse/Pressemitteilungen/Fahrzeugzulassungen/2026/pm25_2026_n_06_26_pm_komplett.html?snn=827402


### PR DESCRIPTION
Submitted by **LeRaffl** via Submit Data form.

- **Country:** Australia
- **Variant:** Whole
- **Source:** KBA
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-06** (monthly) — BEV=84057, PHEV=32212, HEV=83315, PETROL=60796, DIESEL=33862, OTHERS=2136, TOTAL=296378

---

After merge, trigger the **Render country charts** Action to regenerate plots.