### PR TITLE
data: Australia (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/Australia.csv
+++ b/data/Australia.csv
@@ -75,3 +75,4 @@ period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,note
 2026-03,monthly,Whole,VFACTS & Prof. Ray Willis,15839.0,8215.0,17953.0,34694.0,28364.0,,105065.0,
 2026-04,monthly,Whole,VFACTS & Prof. Ray Willis,15459,9628,18162,25399,22414,,91062,Check again for consistency
 2026-05,monthly,Whole,VFACTS & Prof. Ray Willis,21303,9315,19024,28692,25191,,103525,
+2026-06,monthly,Whole,VFACTS & Prof. Ray Willis,32570,16068,20741,34177,31789,,135345,


### PR DESCRIPTION
Submitted by **LeRaffl** via Submit Data form.

- **Country:** Australia
- **Variant:** Whole
- **Source:** VFACTS & Prof. Ray Willis
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-06** (monthly) — BEV=32570, PHEV=16068, HEV=20741, PETROL=34177, DIESEL=31789, TOTAL=135345

---

After merge, trigger the **Render country charts** Action to regenerate plots.