### PR TITLE
ci: bump actions/checkout to v5 and actions/setup-python to v6

### DIFF
--- a/.github/workflows/backfill-italy-rental.yml
+++ b/.github/workflows/backfill-italy-rental.yml
@@ -38,12 +38,12 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: master
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -20,7 +20,7 @@ jobs:
       group: manifest-${{ github.ref }}
       cancel-in-progress: true      # vermeidet parallele Läufe bei vielen kleinen Pushes
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/fetch-acea.yml
+++ b/.github/workflows/fetch-acea.yml
@@ -59,9 +59,9 @@ jobs:
       changed_countries: ${{ steps.fetch.outputs.changed_countries }}
       any_changed: ${{ steps.fetch.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-albania.yml
+++ b/.github/workflows/fetch-albania.yml
@@ -44,9 +44,9 @@ jobs:
       variants_json: ${{ steps.variants.outputs.variants_json }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-austria.yml
+++ b/.github/workflows/fetch-austria.yml
@@ -57,9 +57,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-brazil.yml
+++ b/.github/workflows/fetch-brazil.yml
@@ -27,9 +27,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-canada.yml
+++ b/.github/workflows/fetch-canada.yml
@@ -53,9 +53,9 @@ jobs:
       changed_variants: ${{ steps.changed.outputs.variants }}
       any_changed: ${{ steps.changed.outputs.any }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-chile.yml
+++ b/.github/workflows/fetch-chile.yml
@@ -42,9 +42,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-china.yml
+++ b/.github/workflows/fetch-china.yml
@@ -47,9 +47,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-colombia.yml
+++ b/.github/workflows/fetch-colombia.yml
@@ -35,9 +35,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-denmark.yml
+++ b/.github/workflows/fetch-denmark.yml
@@ -49,9 +49,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-finland.yml
+++ b/.github/workflows/fetch-finland.yml
@@ -50,9 +50,9 @@ jobs:
       any_changed: ${{ steps.commit.outputs.committed == 'true' && steps.changed.outputs.variants_json != '[]' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-ireland.yml
+++ b/.github/workflows/fetch-ireland.yml
@@ -42,9 +42,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-italy.yml
+++ b/.github/workflows/fetch-italy.yml
@@ -74,9 +74,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-japan.yml
+++ b/.github/workflows/fetch-japan.yml
@@ -44,9 +44,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-luxembourg.yml
+++ b/.github/workflows/fetch-luxembourg.yml
@@ -47,9 +47,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-malaysia.yml
+++ b/.github/workflows/fetch-malaysia.yml
@@ -29,9 +29,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-netherlands.yml
+++ b/.github/workflows/fetch-netherlands.yml
@@ -45,9 +45,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-new-zealand.yml
+++ b/.github/workflows/fetch-new-zealand.yml
@@ -61,9 +61,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-poland.yml
+++ b/.github/workflows/fetch-poland.yml
@@ -42,9 +42,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-portugal.yml
+++ b/.github/workflows/fetch-portugal.yml
@@ -39,9 +39,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-singapore.yml
+++ b/.github/workflows/fetch-singapore.yml
@@ -29,9 +29,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-spain.yml
+++ b/.github/workflows/fetch-spain.yml
@@ -85,9 +85,9 @@ jobs:
       committed: ${{ steps.commit.outputs.committed }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-sweden.yml
+++ b/.github/workflows/fetch-sweden.yml
@@ -26,9 +26,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-thailand.yml
+++ b/.github/workflows/fetch-thailand.yml
@@ -47,9 +47,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-turkey.yml
+++ b/.github/workflows/fetch-turkey.yml
@@ -51,9 +51,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-uruguay.yml
+++ b/.github/workflows/fetch-uruguay.yml
@@ -48,9 +48,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/fetch-usa.yml
+++ b/.github/workflows/fetch-usa.yml
@@ -40,9 +40,9 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/ray-article-charts.yml
+++ b/.github/workflows/ray-article-charts.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref_name }}
 

--- a/.github/workflows/render-country.yml
+++ b/.github/workflows/render-country.yml
@@ -77,7 +77,7 @@ jobs:
       # supposed to render. Pinning `ref` to the branch name pulls the
       # latest tip, which also lets sequential matrix entries see each
       # earlier render's commit and push fast-forwards cleanly.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref_name }}
 

--- a/.github/workflows/snapshot-builder.yml
+++ b/.github/workflows/snapshot-builder.yml
@@ -30,9 +30,9 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Node 20 is deprecated on GitHub runners; the v4/v5 action versions
target it and trigger deprecation warnings on every run.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017v1uM3iS47pgC3Y9DquobK