### PR TITLE
fix(netherlands): rolling-window workspace GUIDs to unstick the period cap

### DIFF
--- a/docs/architecture/10-source-netherlands.md
+++ b/docs/architecture/10-source-netherlands.md
@@ -97,9 +97,20 @@ URL (the template) and the one used in every subsequent call (the session).
 
 | Variant | File | Display label | Swing pivot | Saved permalink |
 |---|---|---|---|---|
-| `Whole` | `data/Netherlands.csv` | Netherlands | Instroom Personenauto Nieuw | `a7d36cf5-9dd3-4eca-96e9-9e1b991af9ba` |
-| `Used` | `data/Netherlands_Used.csv` | Netherlands (Used) | Personenauto Occasion import (sum of `> 90 dgn` and `<= 90 dgn`) | `ffaf2d83-0174-4b36-92b9-f7bd96ad4d89` |
-| `HDV` | `data/Netherlands_HDV.csv` | Netherlands (HDV) | Zware bedrijfsvoertuigen Nieuw | `992eb09a-0828-4ef9-97b4-1577ebba3a21` |
+| `Whole` | `data/Netherlands.csv` | Netherlands | Instroom Personenauto Nieuw | `29fcfefb-b82b-47cb-a601-b7c31ebd2901` |
+| `Used` | `data/Netherlands_Used.csv` | Netherlands (Used) | Personenauto Occasion import (sum of `> 90 dgn` and `<= 90 dgn`) | `7f40022a-d4cf-4030-abaf-adf5edf412b3` |
+| `HDV` | `data/Netherlands_HDV.csv` | Netherlands (HDV) | Zware bedrijfsvoertuigen Nieuw | `3ca8fa6f-52a6-4b29-8f43-7bae5200c74c` |
+
+> **Period dimension — use the rolling window, not a fixed month list.**
+> The original permalinks (`a7d36cf5…`, `ffaf2d83…`, `992eb09a…`) had a
+> *static* month selection that silently capped at 2026-04: the fetch kept
+> succeeding but never saw newer months, because opening the saved workspace
+> reproduces exactly the months that were ticked when it was saved. Re-saved
+> 2026-07 using Swing's **"last N months" option (N=36)**, which is dynamic —
+> new months appear automatically. If you ever re-save these, keep the rolling
+> window; don't tick individual months. The 36-month window always overlaps
+> the CSV's existing tail and `upsert` never deletes rows, so the pre-2018-→
+> history is untouched.
 
 ### Why three CSV files instead of one with a `variant` column
 
@@ -292,6 +303,7 @@ change, mirror the change in plots.R.
 | RDW retroactively restates a month with values that differ >50% from what's in the CSV | Upsert prints `WARNING` to the action log but still commits the new values | Decide whether the restatement is real and revert with a manual edit if not |
 | Google Sheet revoked from "anyone with the link" | Backfill script fails with a Google login HTML response | Re-share the sheet, or hardcode the pre-2018 history into a static CSV |
 | The maintainer reconfigures a saved Swing template (e.g. drops a year, changes Aandrijfcategorie selection) | Scraper succeeds but produces wrong-shaped data | The "Captured caption" line in the action log doesn't match `Instroom Personenauto Nieuw - Nederland`. Re-save the workspace with the correct configuration. |
+| **Silent period cap** — a saved workspace with a *static* month list stops at the last month that was ticked when saved | Scraper keeps succeeding (`committed: false`, render skipped) but the CSV never advances — looks exactly like "source hasn't published yet" | The `[Whole] parsed … (2018-01 .. YYYY-MM)` line in the log shows a max period that stops advancing while the portal (opened in a browser) has newer months. Fix: re-save the 3 workspaces with the **rolling "last N months"** option, not individual month ticks (see §3). This bit us 2026-07 — the fetch had silently capped at 2026-04 for months. |
 
 ## 11. Maintenance recipes
 

--- a/scripts/fetch_netherlands.py
+++ b/scripts/fetch_netherlands.py
@@ -59,12 +59,18 @@ from urllib3.util.retry import Retry
 BASE = "https://duurzamemobiliteit.databank.nl"
 
 # Saved Swing workspace templates (configured in the Swing UI via Share Permalink).
-# Each is pre-set to monthly granularity, all years 2018-current selected, and
-# the relevant Voertuigsoort / Aanvoertype dimension picks.
+# Each is pre-set to monthly granularity and the relevant Voertuigsoort /
+# Aanvoertype dimension picks. The period dimension uses Swing's dynamic
+# "last N months" option (N=36) rather than a fixed month list, so the views
+# auto-include new months as RDW publishes them — see docs/architecture/
+# 10-source-netherlands.md §3. (The old templates had a *static* month list
+# that silently capped at 2026-04; re-saved 2026-07 with the rolling window.)
+# The 36-month window always overlaps the CSV's existing tail, and upsert never
+# deletes rows, so the full 2018-→ history is preserved.
 TEMPLATES = {
-    "Whole": "a7d36cf5-9dd3-4eca-96e9-9e1b991af9ba",  # Personenauto Nieuw
-    "Used":  "ffaf2d83-0174-4b36-92b9-f7bd96ad4d89",  # Personenauto Occasion import (>90 + <=90)
-    "HDV":   "992eb09a-0828-4ef9-97b4-1577ebba3a21",  # Zware bedrijfsvoertuigen Nieuw
+    "Whole": "29fcfefb-b82b-47cb-a601-b7c31ebd2901",  # Personenauto Nieuw
+    "Used":  "7f40022a-d4cf-4030-abaf-adf5edf412b3",  # Personenauto Occasion import (>90 + <=90)
+    "HDV":   "3ca8fa6f-52a6-4b29-8f43-7bae5200c74c",  # Zware bedrijfsvoertuigen Nieuw
 }
 
 # Each variant writes to its own CSV. Whole keeps the canonical filename
@@ -185,10 +191,12 @@ def parse_nl_period(label: str) -> str:
 def fetch_table(variant: str, session: requests.Session) -> dict:
     """Bootstrap a session-bound workspace and return its full pivot as JSON.
 
-    GetTableStart only returns the first ~70 rows; for longer tables (Whole and
-    HDV cover ~100 monthly periods) we follow up with GetTableRows to backfill
-    the remainder. Used Imports has only 6 rows (fuels-in-rows layout) so a
-    single GetTableStart suffices.
+    GetTableStart only returns the first ~70 rows; if the pivot is longer we
+    follow up with GetTableRows to backfill the remainder. With the current
+    rolling 36-month window Whole/HDV return 36 period rows (one page, no
+    backfill needed); the pagination loop stays for safety if the window is
+    ever widened. Used Imports has only 6 rows (fuels-in-rows layout) so a
+    single GetTableStart always suffices.
     """
     template_guid = TEMPLATES[variant]
     init_url = f"{BASE}/viewer?workspace_guid={template_guid}"


### PR DESCRIPTION
## What

Swaps the three Netherlands Swing workspace GUIDs for freshly-saved ones that use a **rolling "last 36 months"** period window instead of a static month list.

## Why

The old saved workspaces had a *static* month selection that silently capped at **2026-04**. The fetch kept succeeding every day (`committed: false`, render skipped) but the CSV never advanced — indistinguishable from "RDW hasn't published yet". In reality the portal had May **and** June 2026 (BEV 12,192 / 16,907); opening the saved view only revealed them after manually ticking the months.

Root cause: opening a saved Swing workspace reproduces exactly the months that were ticked when it was saved. A static list never grows.

## Fix

Re-saved all three workspaces with Swing's dynamic "last N months" (N=36) option — they now auto-include new months as RDW publishes them. New GUIDs:

| Variant | New GUID |
|---|---|
| Whole | `29fcfefb-b82b-47cb-a601-b7c31ebd2901` |
| Used | `7f40022a-d4cf-4030-abaf-adf5edf412b3` |
| HDV | `3ca8fa6f-52a6-4b29-8f43-7bae5200c74c` |

The 36-month window always overlaps the CSV's existing tail and `upsert` never deletes rows, so the full pre-2018-→ history is preserved.

## Docs

- §3 note explaining the rolling-window requirement
- new "silent period cap" row in the fragility table (this exact failure mode)
- updated the pagination docstring (36 rows = one page now)

## Next

After merge, run `fetch-netherlands.yml` on master — expect May + June 2026 to land for all three variants and the render to fire.

---
_Generated by [Claude Code](https://claude.ai/code/session_019tCBnFVxTgCXNPndw7NVzA)_