### PR TITLE
fix(netherlands): parse Used's new periods-in-rows fuel-subcolumn layout

### DIFF
--- a/docs/architecture/10-source-netherlands.md
+++ b/docs/architecture/10-source-netherlands.md
@@ -193,14 +193,23 @@ Swing pivots can be returned in either orientation:
 
 | Orientation | Returned for | `headRows` contains | `headCols` contains |
 |---|---|---|---|
-| Periods-in-rows | Whole, HDV | Period labels (`"31 januari 2018"` …) | Fuel labels (one level) |
-| Fuels-in-rows | Used | Fuel labels (`BEV`, `FCEV`, `PHEV` …) | Period labels **and** sub-period categories (two levels — `> 90 dgn` and `<= 90 dgn` per period) |
+| Periods-in-rows, one col/fuel | Whole, HDV | Period labels (`"31 januari 2018"` …) | Fuel labels (one level) |
+| Periods-in-rows, fuel × sub-col | **Used (current)** | Period labels | Fuels on the **outer** level, each spanning two sub-columns (`Occasion import > 90 dgn` / `<= 90 dgn`) — summed |
+| Fuels-in-rows | Used (legacy template) | Fuel labels (`BEV`, `FCEV`, `PHEV` …) | Period labels + `> 90`/`<= 90` sub-categories (two levels) |
 
-`parse_table` detects which case applies by checking whether the first
-`headRows` entry is in the known fuel-label set (`NL_FUELS`). For the
-fuels-in-rows case it also walks the outer-level `headCols` propagating
-the period label forward across the sub-columns it spans, then sums the
-sub-columns per period.
+`parse_table` first checks whether the first `headRows` entry is a fuel
+(`NL_FUELS`) → fuels-in-rows (`_parse_fuels_in_rows`); otherwise
+periods-in-rows (`_parse_periods_in_rows`). The periods-in-rows parser finds
+whichever `headCols` level actually carries fuel names, propagates each fuel
+label across the sub-columns it spans (blank cell = span continuation), and
+sums columns per fuel — so it handles both Whole/HDV (one column per fuel)
+and Used (two `> 90`/`<= 90` sub-columns per fuel).
+
+> **Watch the Used orientation when re-saving.** Re-saving the Used workspace
+> with the rolling-36-month window (2026-07) flipped it from *fuels-in-rows*
+> to *periods-in-rows with fuel sub-columns*. The parser now handles that, but
+> it silently produced **0 rows** until fixed — see the "variant parses 0 rows"
+> diagnostic in `main()`, which dumps the pivot shape when this recurs.
 
 ## 6. Backfill: pre-2018 history
 

--- a/scripts/fetch_netherlands.py
+++ b/scripts/fetch_netherlands.py
@@ -476,6 +476,25 @@ def main() -> None:
         print(f"[{variant}] parsed {len(rows)} non-zero months "
               f"({min(rows, default='—')} .. {max(rows, default='—')})")
         if not rows:
+            # A variant returning zero rows is NOT normal — it means the parser
+            # couldn't read the pivot (e.g. a re-saved workspace changed shape).
+            # Dump the raw header structure so the format change is diagnosable,
+            # then keep going so the other variants still update.
+            import json as _json
+            def _shape(x, depth=0):
+                if isinstance(x, list):
+                    head = x[:4]
+                    return [_shape(e, depth + 1) for e in head] + (
+                        ["…(+%d)" % (len(x) - 4)] if len(x) > 4 else [])
+                if isinstance(x, dict):
+                    return {k: _shape(v, depth + 1) for k, v in list(x.items())[:8]}
+                return x
+            print(f"[{variant}] WARNING: 0 rows parsed — pivot shape follows")
+            print(f"[{variant}]   caption : {data.get('caption')!r}")
+            print(f"[{variant}]   totalRows/Cols: {data.get('totalRows')}/{data.get('totalCols')}")
+            print(f"[{variant}]   headRows: {_json.dumps(_shape(data.get('headRows')), ensure_ascii=False)[:1200]}")
+            print(f"[{variant}]   headCols: {_json.dumps(_shape(data.get('headCols')), ensure_ascii=False)[:1200]}")
+            print(f"[{variant}]   rowData[0:2]: {_json.dumps(_shape(data.get('rowData'))[:2], ensure_ascii=False)[:800]}")
             continue
         keyed = {(p, variant): r for p, r in rows.items()}
         added, updated = upsert_csv(CSV_PATHS[variant], keyed)

--- a/scripts/fetch_netherlands.py
+++ b/scripts/fetch_netherlands.py
@@ -37,9 +37,13 @@ Brief recap (so the script reads on its own):
       FCEV + Overig -> OTHERS;  HEV column is always blank (RDW doesn't
       split it; full hybrids fold into Benzine/Diesel upstream).
 * Dutch locale: "." is thousands separator (6.863 == 6863). "&nbsp;" == 0.
-* Two table orientations are possible (Whole/HDV return periods-in-rows;
-  Used returns fuels-in-rows with a 2-level period × sub-column header).
-  The parser detects which case applies from the headRows labels.
+* Table orientation varies by view. Whole/HDV return periods-in-rows with one
+  column per fuel. Used returns periods-in-rows too, but with fuels on the
+  OUTER column level, each spanning two sub-columns ("Occasion import > 90 dgn"
+  / "<= 90 dgn") which the parser sums. (An older Used template returned
+  fuels-in-rows; _parse_fuels_in_rows is kept for that shape.) The parser
+  picks the branch from the headRows labels and locates the fuel header level
+  by matching NL_FUELS.
 """
 import argparse
 import base64
@@ -260,11 +264,13 @@ def parse_table(data: dict, variant: str) -> dict[str, dict[str, float]]:
     Parse a Swing GetTableStart response into {period: {fuel: value}}.
 
     Two layouts are possible:
-      A. Periods in headRows, fuels in headCols   (Whole, HDV)
-      B. Fuels in headRows, periods in headCols   (Used Imports)
+      A. Periods in headRows, fuels in headCols   (Whole, HDV, Used)
+      B. Fuels in headRows, periods in headCols   (legacy Used template)
 
-    For layout B, Used Imports has a 2-level column header: each period spans
-    two sub-columns ("Occasion import > 90 dgn" and "<= 90 dgn") which we sum.
+    In layout A, Used carries the fuel names on the OUTER headCols level with
+    each fuel spanning two sub-columns ("> 90 dgn" / "<= 90 dgn") that get
+    summed; _parse_periods_in_rows handles both the one-column-per-fuel and the
+    sub-column shapes. Layout B is the older fuels-in-rows Used template.
     """
     row_first = data["headRows"][0][0]["d"]
     fuels_in_rows = row_first in NL_FUELS
@@ -275,17 +281,49 @@ def parse_table(data: dict, variant: str) -> dict[str, dict[str, float]]:
 
 
 def _parse_periods_in_rows(data: dict, variant: str) -> dict[str, dict[str, float]]:
-    """Layout A: periods are rows, fuels are columns (Whole, HDV)."""
-    fuel_labels = [hc["d"] for hc in data["headCols"][-1]]  # innermost level
+    """Layout A: periods are rows, fuels are columns.
+
+    Handles two column shapes with one code path:
+      * Whole/HDV — one column per fuel (single-level, or fuels at the
+        innermost level).
+      * Used — fuels on the OUTER header level, each spanning two sub-columns
+        ("Occasion import > 90 dgn" / "<= 90 dgn") which we sum. (Swing emits
+        this shape after the workspace was re-saved with the rolling window.)
+
+    We locate whichever headCols level actually carries fuel names, propagate
+    each fuel label across the sub-columns it spans (blank cell = span
+    continuation), then sum all columns belonging to the same fuel per period.
+    """
+    # Find the header level whose labels include recognisable fuel names.
+    fuel_level: list[str] | None = None
+    for level in data["headCols"]:
+        labels = [c.get("d", "") for c in level]
+        if any(lbl in NL_FUELS for lbl in labels):
+            fuel_level = labels
+            break
+    if fuel_level is None:
+        # No fuel header found → let the caller's 0-rows diagnostic dump fire.
+        return {}
+
+    # Propagate the fuel label across every column it spans.
+    fuel_per_col: list[str | None] = []
+    current: str | None = None
+    for lbl in fuel_level:
+        if lbl:
+            current = lbl
+        fuel_per_col.append(current)
+
     period_labels = [r[0]["d"] for r in data["headRows"]]
     out: dict[str, dict[str, float]] = {}
     for i, period_label in enumerate(period_labels):
         period = parse_nl_period(period_label)
         row_cells = data["rowData"][i]
-        out[period] = {
-            fuel_labels[j]: parse_nl_number(row_cells[j]["d"])
-            for j in range(len(fuel_labels))
-        }
+        acc: dict[str, float] = {}
+        for j, fuel in enumerate(fuel_per_col):
+            if fuel is None or j >= len(row_cells):
+                continue
+            acc[fuel] = acc.get(fuel, 0.0) + parse_nl_number(row_cells[j]["d"])
+        out[period] = acc
     return out
 
 


### PR DESCRIPTION
## What

Teaches the Netherlands parser to read the **Used** variant's new pivot layout, so Used advances to May/June like Whole and HDV already did.

## Why

After the rolling-36-month re-save (#158), the Used workspace came back in a **different Swing layout**: periods-in-rows, with the fuels on the *outer* column header level, each spanning two sub-columns (`Occasion import > 90 dgn` / `<= 90 dgn`). `_parse_periods_in_rows` read the *innermost* header level (the `>90`/`<=90` labels) as fuel names, matched nothing in `FUEL_MAP`, and produced **0 rows** — so Used silently stayed at 2026-04 while Whole/HDV moved to June (`committed: false`, no error).

Diagnosed with a shape-dump added when any variant parses 0 rows (kept as a safety net):
```
[Used] totalRows/Cols: 36/12
[Used] headCols L0: BEV, —, FCEV, —, …   (6 fuels × 2 cols)
[Used] headCols L1: > 90 dgn, <= 90 dgn, …
```

## Fix

`_parse_periods_in_rows` now locates whichever `headCols` level actually carries fuel names (`NL_FUELS`), propagates each fuel label across the sub-columns it spans, and sums columns per fuel. One code path handles both:
- **Whole/HDV** — one column per fuel
- **Used** — two `>90`/`<=90` sub-columns per fuel (summed)

Verified locally against the dumped structure: BEV July 2023 = 1281 + 19 = **1300**, FCEV+Overig fold into OTHERS.

## Also

- Keeps the "variant parses 0 rows" WARNING + shape dump so this class of silent failure is diagnosable next time.
- Docs: §5 orientation table + a re-save warning + module/parse docstrings.

## Next

After merge, run `fetch-netherlands.yml` on master (or `--force`) — Used should finally pick up May + June and render.

---
_Generated by [Claude Code](https://claude.ai/code/session_019tCBnFVxTgCXNPndw7NVzA)_