### PR TITLE
fix(ci): retry transient customs.gov.np errors + rebase manifest push

### DIFF
--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -47,3 +47,7 @@ jobs:
             schedule-*.html
             schedule.ics
           message: "chore: update manifest + schedule (CI)"
+          # Rebase onto the remote tip before pushing so a concurrent push
+          # (e.g. a data-fetch job committing at the same time) doesn't reject
+          # this one with a non-fast-forward error.
+          pull: '--rebase --autostash'

--- a/scripts/fetch_nepal.py
+++ b/scripts/fetch_nepal.py
@@ -109,6 +109,7 @@ import csv
 import io
 import re
 import sys
+import time
 import unicodedata
 from pathlib import Path
 
@@ -226,10 +227,27 @@ def anchor_text(raw: str) -> str:
     return re.sub(r"\s+", " ", txt).strip()
 
 
-def get(session: requests.Session, url: str) -> str:
-    r = session.get(url, timeout=90)
-    r.raise_for_status()
-    return r.text
+def get(session: requests.Session, url: str, *, retries: int = 4) -> str:
+    """GET a page, retrying transient failures (5xx / timeouts / connection
+    errors). customs.gov.np intermittently answers 503, which otherwise fails
+    the whole scheduled run for a purely temporary outage."""
+    last_exc: Exception | None = None
+    for attempt in range(retries):
+        try:
+            r = session.get(url, timeout=90)
+            r.raise_for_status()
+            return r.text
+        except (requests.HTTPError, requests.ConnectionError,
+                requests.Timeout) as exc:
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            # Don't retry genuine client errors (404 etc.) — only 5xx/network.
+            if status is not None and status < 500:
+                raise
+            last_exc = exc
+            if attempt < retries - 1:
+                time.sleep(2 ** attempt)  # 1s, 2s, 4s, 8s
+    assert last_exc is not None
+    raise last_exc
 
 
 def discover_fy_categories(session: requests.Session) -> dict[int, list[str]]:


### PR DESCRIPTION
- fetch_nepal: get() now retries 5xx/timeout/connection errors with
  exponential backoff so a transient 503 from customs.gov.np no longer
  fails the whole scheduled run.
- build-manifest: add pull: --rebase --autostash so concurrent pushes
  don't reject with non-fast-forward (matches render-country/fetch-nepal).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015XqfGM6Aq7DsAvnYQNex73