### PR TITLE
data: South Korea (Whole) — 2 added, 0 corrected

### DIFF
--- a/data/South Korea.csv
+++ b/data/South Korea.csv
@@ -2,7 +2,7 @@ period,time_interval,variant,source,BEV,PHEV,HEV,OTHERS,ICE,TOTAL,notes
 2017-01,monthly,Whole,motir.go.kr,369.0,4.0,3925.0,5.0,119281.0,123584.0,
 2017-02,monthly,Whole,https://www.motir.go.kr#anchor1,486.0,32.0,4465.0,0.0,131850.0,136833.0,
 2017-03,monthly,Whole,https://www.kama.or.kr/NewsController?cmd=V&boardmaster_id=Register&board_id=497&menunum=0003&searchGubun=&searchValue=&pagenum=1,874.0,16.0,5895.0,9.0,162206.0,169000.0,
-2017-04,monthly,Whole,https://www.motir.go.kr/kor/article/ATCL3f49a5a8c?mno=&rowPageC=0&displayAuthor=&searchCategory=1&schClear=on&startDtD=&endDtD=&searchCondition=1&searchKeyword=ìëì°¨ì°ì+ëí¥,862.0,25.0,6364.0,1.0,146326.0,153578.0,
+2017-04,monthly,Whole,https://www.motir.go.kr/kor/article/ATCL3f49a5a8c?mno=&rowPageC=0&displayAuthor=&searchCategory=1&schClear=on&startDtD=&endDtD=&searchCondition=1&searchKeyword=Ã¬ÂÂÃ«ÂÂÃ¬Â°Â¨Ã¬ÂÂ°Ã¬ÂÂ+Ã«ÂÂÃ­ÂÂ¥,862.0,25.0,6364.0,1.0,146326.0,153578.0,
 2017-05,monthly,Whole,motir.go.kr,854.0,19.0,7116.0,6.0,147740.0,155735.0,
 2017-06,monthly,Whole,motir.go.kr,972.0,39.0,8628.0,18.0,155062.0,164719.0,
 2017-07,monthly,Whole,motir.go.kr,1371.0,61.0,8061.0,10.0,139637.0,149140.0,
@@ -111,3 +111,5 @@ period,time_interval,variant,source,BEV,PHEV,HEV,OTHERS,ICE,TOTAL,notes
 2026-02,monthly,Whole,motir.go.kr,36332,870,38468,467,47138,123275,
 2026-03,monthly,Whole,motir.go.kr,41237,1031,54516,1120,66906,164810,taken from Robbie, scraping yet to implement
 2026-04,monthly,Whole,motir.go.kr,38927,951,50782,500,60533,151693,taken from Robbie, scraping yet to implement
+2026-05,monthly,Whole,motir.go.kr,35455,976,40387,462,50028,127308,
+2026-06,monthly,Whole,motir.go.kr,39031,1113,53578,500,65503,159725,


### PR DESCRIPTION
Submitted by **Anonymous** via Submit Data form.

- **Country:** South Korea
- **Variant:** Whole
- **Source:** motir.go.kr
- **Added:** 2
- **Corrected:** 0

### New rows
- **2026-05** (monthly) — BEV=35455, PHEV=976, HEV=40387, OTHERS=462, ICE=50028, TOTAL=127308
- **2026-06** (monthly) — BEV=39031, PHEV=1113, HEV=53578, OTHERS=500, ICE=65503, TOTAL=159725

---

After merge, trigger the **Render country charts** Action to regenerate plots.