### PR TITLE
fix(ci): resilientere Fetch/Snapshot-Workflows

### DIFF
--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -47,3 +47,7 @@ jobs:
             schedule-*.html
             schedule.ics
           message: "chore: update manifest + schedule (CI)"
+          # Rebase onto the remote tip before pushing so a concurrent push
+          # (e.g. a data-fetch job committing at the same time) doesn't reject
+          # this one with a non-fast-forward error.
+          pull: '--rebase --autostash'

--- a/.github/workflows/snapshot-builder.yml
+++ b/.github/workflows/snapshot-builder.yml
@@ -23,6 +23,11 @@ on:
 jobs:
   snapshot:
     runs-on: ubuntu-latest
+    # The snapshot script is CPU-bound over local CSVs and finishes in
+    # seconds; anything longer means a stuck runner or a hung step. Cap it so
+    # a hang fails fast and visibly instead of burning ~40 min then being
+    # cancelled (as happened on the 2026-07-25 scheduled run).
+    timeout-minutes: 10
     permissions:
       contents: write
     concurrency:
@@ -48,3 +53,6 @@ jobs:
           add: builder_history
           message: 'chore: snapshot Builder curves (CI)'
           default_author: github_actions
+          # Rebase onto the remote tip before pushing so a concurrent push
+          # doesn't reject this one with a non-fast-forward error.
+          pull: '--rebase --autostash'

--- a/scripts/fetch_nepal.py
+++ b/scripts/fetch_nepal.py
@@ -109,6 +109,7 @@ import csv
 import io
 import re
 import sys
+import time
 import unicodedata
 from pathlib import Path
 
@@ -226,10 +227,27 @@ def anchor_text(raw: str) -> str:
     return re.sub(r"\s+", " ", txt).strip()
 
 
-def get(session: requests.Session, url: str) -> str:
-    r = session.get(url, timeout=90)
-    r.raise_for_status()
-    return r.text
+def get(session: requests.Session, url: str, *, retries: int = 4) -> str:
+    """GET a page, retrying transient failures (5xx / timeouts / connection
+    errors). customs.gov.np intermittently answers 503, which otherwise fails
+    the whole scheduled run for a purely temporary outage."""
+    last_exc: Exception | None = None
+    for attempt in range(retries):
+        try:
+            r = session.get(url, timeout=90)
+            r.raise_for_status()
+            return r.text
+        except (requests.HTTPError, requests.ConnectionError,
+                requests.Timeout) as exc:
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            # Don't retry genuine client errors (404 etc.) — only 5xx/network.
+            if status is not None and status < 500:
+                raise
+            last_exc = exc
+            if attempt < retries - 1:
+                time.sleep(2 ** attempt)  # 1s, 2s, 4s, 8s
+    assert last_exc is not None
+    raise last_exc
 
 
 def discover_fy_categories(session: requests.Session) -> dict[int, list[str]]:


### PR DESCRIPTION
Behebt drei wiederkehrende Fehlerklassen in den geplanten Workflows.

## Fetch Nepal data — transientes 503
`customs.gov.np` antwortet zeitweise mit `503 Service Unavailable`. `get()` machte nur einen Versuch, sodass ein temporärer Ausfall den ganzen geplanten Lauf abbrach.
- `scripts/fetch_nepal.py`: `get()` wiederholt jetzt 5xx/Timeout/Connection-Fehler mit exponentiellem Backoff (1s/2s/4s/8s). Echte Client-Fehler (404 etc.) werden weiterhin sofort durchgereicht.

## Build manifest — non-fast-forward Push
Bei parallelen Pushes anderer Jobs wurde der Commit mit `non-fast-forward` abgelehnt.
- `.github/workflows/build-manifest.yml`: `pull: '--rebase --autostash'` am Commit-Step ergänzt (entspricht dem Muster in `render-country.yml`/`fetch-nepal.yml`).

## Snapshot Builder curves — 41-Min-Hang → cancelled
Der geplante Lauf am 25.07. hing ~41 Min und wurde abgebrochen; kein Snapshot committet. Das Skript ist rein CPU-gebunden über lokale CSVs und läuft in <1s.
- `.github/workflows/snapshot-builder.yml`: `timeout-minutes: 10`, damit ein Hang schnell/sichtbar scheitert; zusätzlich `pull: '--rebase --autostash'` am Commit-Step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015XqfGM6Aq7DsAvnYQNex73)_