### PR TITLE
docs(georgia): direkter Link auf die Zulassungsstatistik statt auf die Geostat-Startseite

### DIFF
--- a/docs/architecture/country_source_stubs.yaml
+++ b/docs/architecture/country_source_stubs.yaml
@@ -349,7 +349,7 @@ stubs:
     method: manual
     summary: "New-registration data for Georgia from the National Statistics Office (Geostat)."
     source_name: "Geostat — National Statistics Office of Georgia"
-    source_url: "https://www.geostat.ge/en"
+    source_url: "https://automobile.geostat.ge/en/automobiles/rating"
     underlying: "Geostat — National Statistics Office of Georgia"
     variants: [Whole]
     data_file: "data/Georgia.csv"

--- a/sources/georgia.html
+++ b/sources/georgia.html
@@ -97,10 +97,10 @@ table.defs th{width:190px;color:var(--muted);font-weight:600}
 
   <h2>Raw source</h2>
   <p>Verify the numbers at the upstream:</p>
-  <p><a class="source-btn" href="https://www.geostat.ge/en">Geostat — National Statistics Office of Georgia ↗</a></p>
+  <p><a class="source-btn" href="https://automobile.geostat.ge/en/automobiles/rating">Geostat — National Statistics Office of Georgia ↗</a></p>
 
   <h2>How the data flows</h2>
-  <div class="flow"><div class="flow-node"><div class="flow-title">Origin</div><div class="flow-sub">Geostat — National Statistics Office of Georgia</div></div><div class="flow-arrow" aria-hidden="true">▼</div><div class="flow-node"><div class="flow-title">Source / API</div><div class="flow-sub"><a href="https://www.geostat.ge/en">Geostat — National Statistics Office of Georgia</a></div></div><div class="flow-arrow" aria-hidden="true">▼</div><div class="flow-node"><div class="flow-title">Store</div><div class="flow-sub"><a href="https://github.com/LeRaffl/LeRaffl-Gallery/blob/master/data/Georgia.csv"><code>data/Georgia.csv</code></a></div></div><div class="flow-arrow" aria-hidden="true">▼</div><div class="flow-node"><div class="flow-title">Gallery</div><div class="flow-sub"><a href="../">BEV Trajectories gallery</a></div></div></div>
+  <div class="flow"><div class="flow-node"><div class="flow-title">Origin</div><div class="flow-sub">Geostat — National Statistics Office of Georgia</div></div><div class="flow-arrow" aria-hidden="true">▼</div><div class="flow-node"><div class="flow-title">Source / API</div><div class="flow-sub"><a href="https://automobile.geostat.ge/en/automobiles/rating">Geostat — National Statistics Office of Georgia</a></div></div><div class="flow-arrow" aria-hidden="true">▼</div><div class="flow-node"><div class="flow-title">Store</div><div class="flow-sub"><a href="https://github.com/LeRaffl/LeRaffl-Gallery/blob/master/data/Georgia.csv"><code>data/Georgia.csv</code></a></div></div><div class="flow-arrow" aria-hidden="true">▼</div><div class="flow-node"><div class="flow-title">Gallery</div><div class="flow-sub"><a href="../">BEV Trajectories gallery</a></div></div></div>
 
   <h2>Definitions &amp; scope</h2>
   <table class="defs"><tr><th>Acquisition</th><td>Manual — entered by hand from the published source</td></tr><tr><th>Variants</th><td>Whole</td></tr></table>


### PR DESCRIPTION
Der Source-Button zeigte auf `https://www.geostat.ge/en`, also die Startseite des Statistikamts. Wer von der Gallery aus eine Zahl nachprüfen will, landet dort auf einem allgemeinen Portal und muss selbst suchen.

Jetzt direkt:

```diff
-source_url: "https://www.geostat.ge/en"
+source_url: "https://automobile.geostat.ge/en/automobiles/rating"
```

## Umfang

Nur `docs/architecture/country_source_stubs.yaml` und die daraus generierte `sources/georgia.html`. Die übrigen 50 Seiten und der Index sind nach dem Rebuild byte-identisch — `--check` läuft mit `OK — 51 valid entries` durch.

## Was ich nicht verifizieren konnte

`*.geostat.ge` ist von meiner Umgebung aus per Egress-Policy geblockt (403 am Proxy), die Seite ließ sich also nicht öffnen. Die URL kommt von dir. Zwei Folgen daraus:

- **Bitte den gerenderten Link vor dem Merge einmal anklicken.** Ein toter Link auf der öffentlichen Gallery wäre schlechter als der bisherige Umweg über die Startseite.
- Ich habe `source_name` bewusst **nicht** umbenannt. Der Pfad `/automobiles/rating` legt eher eine Rangliste als eine Zulassungstabelle nahe, und ohne die Seite gesehen zu haben wollte ich das Button-Label nicht auf eine Vermutung setzen. Falls die Seite etwas Spezifischeres zeigt, ist ein passenderer Name eine Zeile im YAML — sag an, dann ziehe ich nach.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsQ1X1YisTskUF3QC9LUrX)_