### PR TITLE
data: Georgia (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/Georgia.csv
+++ b/data/Georgia.csv
@@ -36,3 +36,4 @@ period,time_interval,variant,source,BEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,notes
 2025-08,quarterly,Whole,National Statistics Office of Georgia,2150.0,10829.0,28334.0,5049.0,180.0,46542.0,
 2025-11,quarterly,Whole,National Statistics Office of Georgia,1805.0,10088.0,24822.0,4847.0,157.0,41719.0,
 2026-02,quarterly,Whole,National Statistics Office of Georgia,2109.0,8191.0,20612.0,4265.0,123.0,35300.0,
+2026-05,quarterly,Whole,https://automobile.geostat.ge/en/automobiles/rating,3724,11092,23383,5093,157,43449,PETROL = Gasoline+Gasoline-gas


### PR DESCRIPTION
Submitted by **Anonymous** via Submit Data form.

- **Country:** Georgia
- **Variant:** Whole
- **Source:** https://automobile.geostat.ge/en/automobiles/rating
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-05** (quarterly) — BEV=3724, HEV=11092, PETROL=23383, DIESEL=5093, OTHERS=157, TOTAL=43449

---

After merge, trigger the **Render country charts** Action to regenerate plots.