### PR TITLE
fix(ttm): first-year periods must feed the rolling window, not be dropped before it

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -59,11 +59,14 @@ compute_ttm_long <- function(df) {
   m <- df[df$time_interval == last_ti, ]
   m <- m[order(m$year), ]
   if (nrow(m) < window) return(NULL)
-  # Mirror the historical script: drop the first calendar year before rolling,
-  # so the displayed TTM series doesn't include partial-window noise at the
-  # left edge (monthly: 12 months; quarterly: 4 quarters).
-  m <- m[m$year >= min(m$year) + 1, ]
-  if (nrow(m) < window) return(NULL)
+  # Hide the first calendar year of the series so the displayed TTM doesn't open
+  # with partial-window noise at the left edge (monthly: 12 months; quarterly:
+  # 4 quarters). This is a DISPLAY cut only: those periods must stay in `m` so
+  # the rolling window can still see them (a Jan point needs the prior 11
+  # months; a Q1 point needs the prior 3 quarters). Dropping them from `m` here
+  # instead would starve the next year's early windows, shifting the whole
+  # series one window to the right and mis-placing every year-start tick.
+  display_from <- min(m$year) + 1
 
   fuel_cols <- c("BEV","PHEV","EREV","HEV","MHEV","PETROL","DIESEL","GAS","CNG","LPG","FLEXFUEL","ETHANOL","OTHERS","ICE")
   present <- fuel_cols[fuel_cols %in% names(m)]
@@ -129,8 +132,9 @@ compute_ttm_long <- function(df) {
     ttm[["OTHERS"]] <- pmax(0, total_ttm - excl_sum) / total_ttm
   }
 
-  # Keep only rows where every present column has a complete 12-month window.
-  keep <- which(any_present)
+  # Keep only rows where every present column has a complete 12-month window,
+  # and drop the hidden first display year (see `display_from` above).
+  keep <- which(any_present & m$year >= display_from)
   if (length(keep) == 0) return(NULL)
   months <- substr(m$period[keep], 1, 7)
   out <- data.frame(month = months, stringsAsFactors = FALSE)


### PR DESCRIPTION
## Problem

Reported: the Georgia TTM chart looked *implausible* — "Jan 2018" and "Jan 2019" sat right on top of each other, and the shares no longer matched the older published chart.

Root cause is a single ordering bug in `compute_ttm_long` (`R/data.R`). The first calendar year was dropped from `m` **before** the trailing-window sum ran:

```r
m <- m[m$year >= min(m$year) + 1, ]   # drops 2017 entirely
... then the rolling window runs on what's left
```

So the following year's early periods lost the prior quarters/months a complete window needs. The series started **one full window too late**, and since the first surviving bar of each year is tagged as that year's axis tick, every year-start label landed on the wrong bar.

### Symptoms on Georgia (quarterly)
| | correct (old chart) | buggy (current) |
|---|---|---|
| first bar | `2018-02`, Hybrid **28.5%** | `2018-11`, Hybrid **34.6%** — labelled "Jan 2018" |
| year ticks | 4 bars apart | "Jan 2018"/"Jan 2019" one bar apart |

The raw data (`data/Georgia.csv`, unchanged since the bulk import) confirms `2018-02` has a complete trailing-4-quarter window using the 2017 quarters — it should never have been dropped.

## Fix

Keep the first-year periods in `m` (so the rolling window can see them) and move the "hide the first calendar year" cut to the **display** step:

```r
display_from <- min(m$year) + 1
...
keep <- which(any_present & m$year >= display_from)
```

## Verification

Re-running the real pipeline on Georgia after the fix:

- first displayed bar back to `2018-02` / Hybrid **28.5%** (matches the older published chart and a hand-computed trailing-4-quarter check)
- year-start ticks: `2018-02, 2019-02, 2020-02, …` — evenly spaced, no collision
- full series still runs to the latest quarter

## Scope

This lives in the **global** `compute_ttm_long`, so it corrects **every** country's TTM chart — each currently starts one window too late and mislabels its first year. It's just most visible on quarterly, few-point Georgia. All TTM charts should be re-rendered after merge. No colour/palette changes.