### PR TITLE
Document Western Balkans expansion candidates and Serbia verification

### DIFF
--- a/docs/architecture/27-source-albania.md
+++ b/docs/architecture/27-source-albania.md
@@ -278,6 +278,21 @@ Andrew's series includes LPG as a separate column while we fold it into OTHERS,
 and minor retroactive corrections appear in the source.  Large deviations
 (hundreds of cars) indicate a parsing or filter regression.
 
+**Do NOT reconcile against CEauto / new-car trade figures (cross-checked
+2026-07).** CEauto (Central European Automotive Report, surfaced via Best
+Selling Cars Blog) publishes an Albania *passenger-car* series that is **~5×
+smaller** than ours and must never be treated as a discrepancy: it counts
+**new cars only**, whereas we count **all first registrations incl. imported
+used** (§6). H1-2026: CEauto ≈ **7,220** vs our Whole ≈ **38,716**. The gap is
+the used-import flow. CEauto's new-only total actually ≈ our electrified subset
+(BEV+PHEV+HEV) plus a small new-ICE tail — i.e. it *corroborates* our data as a
+subset rather than contradicting it. The denominator choice is the whole point:
+BEV share on our (whole-flow) total is ~9% (Jun-2026: 728/7,945), but ~50% on
+CEauto's new-only base — mixing the two, or "fixing" our numbers to match
+CEauto, would break the gallery's used-import-market lens (§14) and the
+cross-country comparison. If a future maintainer asks "why are our Albania
+numbers 5× the trade press?", this is the answer.
+
 ## 7. Historical data (pre-2026)
 
 Each DPSHTRR Looker report is scoped to a single calendar year, but a separate

--- a/docs/architecture/33-expansion-candidates.md
+++ b/docs/architecture/33-expansion-candidates.md
@@ -214,6 +214,49 @@ so the next session doesn't redo the search.
 
 ---
 
+## Tier — Western Balkans / former Yugoslavia gap (2026-07)
+
+The gallery covers Croatia, Slovenia and Albania in the region but has a hole
+across the rest of former Yugoslavia (Serbia, Bosnia, North Macedonia,
+Montenegro, Kosovo). Desk investigation below; **web-research only, endpoints
+not yet exercised** — verify machine-access + the BEV/PHEV/HEV split before
+building.
+
+**On CEauto (Central European Automotive Report).** It surfaces Balkan car
+numbers (e.g. via Best Selling Cars Blog) but is a **paid B2B aggregator**, not
+a registry — fails the bar at (a) *secondary source* and (c) *subscription
+paywall*, and its public teasers carry only totals + brand ranking, no free
+6-way fuel split. **Do not build a fetcher on CEauto.** Its only use is as a
+cross-check (the role BSCB played for Albania) and as a pointer to each
+country's underlying primary source.
+
+| Country | Best primary source | Cadence | Fuel split | Scope | Verdict |
+|---|---|---|---|---|---|
+| 🇷🇸 Serbia | **Uvoznici vozila** (importers' assoc.; MoI first-reg data) — "Overview of the New Vehicle Market (M1/N1/L)" | monthly | Petrol/Diesel/Hybrid/BEV (**verify PHEV vs HEV**) | **New only, ACEA-style** | ⭐ **Build candidate #1** |
+| 🇧🇦 Bosnia | bhas.gov.ba monthly TRANSPORT bulletin (from IDDEEA) | monthly PDF | may lump "alternative fuel" (~3.6%) — **verify granularity** | first-reg **incl. imported used** (Albania-like) | Candidate — verify fuel split |
+| 🇲🇰 North Macedonia | stat.gov.mk | thin | thin | — | Weak (≈190 BEV total; signal too small) |
+| 🇲🇪 Montenegro | MONSTAT | ~annual | thin | — | Weak |
+| 🇽🇰 Kosovo | Kosovo Agency of Statistics | ~annual | thin | — | Weak |
+| all (backfill/cross-check) | **Eurostat `road_eqr_carpda`** + **UNECE** road-fleet PX tables | **annual only, ~1yr lag** | motor-energy, ACEA-congruent | new | annual backfill / cross-check, not a monthly primary |
+
+**ACEA-consistency caveat (matters for this region).** Only Serbia
+(importers' association) and the Eurostat/UNECE annuals are *new-car* series.
+The statistical-office / IDDEEA routes (Bosnia, and the same lens we already use
+for Albania) count **first registrations including imported used vehicles** —
+fine for the gallery's whole-flow view of a used-import-dominated market
+(§14 principle), but **not comparable to ACEA new-registration counts** and must
+carry a footnote saying so. Mixing the two reproduces the Albania-vs-CEauto
+denominator break (~5× on the total, BEV share 9% vs ~50%). Every
+incl.-imported-used country therefore needs the standard footnote already
+attached to Albania in `footnotes.csv`.
+
+**Order of attack:** Serbia first (biggest market, real industry body,
+ACEA-clean, growing EV signal) → Bosnia (only after confirming the bulletin
+separates BEV/PHEV/HEV) → skip North Macedonia / Montenegro / Kosovo for now
+(EV signal ≈ 0, monthly data too thin — same failure mode as the §14 rejects).
+
+---
+
 ## Alternative axis — variant leads for countries already on the gallery
 
 Unverified leads (training-knowledge level, no fetch performed — confirm the

--- a/docs/architecture/33-expansion-candidates.md
+++ b/docs/architecture/33-expansion-candidates.md
@@ -218,9 +218,10 @@ so the next session doesn't redo the search.
 
 The gallery covers Croatia, Slovenia and Albania in the region but has a hole
 across the rest of former Yugoslavia (Serbia, Bosnia, North Macedonia,
-Montenegro, Kosovo). Desk investigation below; **web-research only, endpoints
-not yet exercised** — verify machine-access + the BEV/PHEV/HEV split before
-building.
+Montenegro, Kosovo). Desk investigation below. Serbia's data model is now
+**confirmed from the actual published reports** (see the Serbia subsection); the
+other countries remain web-research only — verify machine-access + the
+BEV/PHEV/HEV split before building.
 
 **On CEauto (Central European Automotive Report).** It surfaces Balkan car
 numbers (e.g. via Best Selling Cars Blog) but is a **paid B2B aggregator**, not
@@ -232,7 +233,7 @@ country's underlying primary source.
 
 | Country | Best primary source | Cadence | Fuel split | Scope | Verdict |
 |---|---|---|---|---|---|
-| 🇷🇸 Serbia | **Uvoznici vozila** (importers' assoc.; MoI first-reg data) — "Overview of the New Vehicle Market (M1/N1/L)" | monthly | Petrol/Diesel/Hybrid/BEV (**verify PHEV vs HEV**) | **New only, ACEA-style** | ⭐ **Build candidate #1** |
+| 🇷🇸 Serbia | **Uvoznici vozila** (importers' assoc.; MoI first-reg data) — "Overview of the New Vehicle Market (M1/N1/L)" | monthly totals; **fuel split only quarterly** | Petrol/Diesel/**Hybrid (combined)**/BEV/Other — *no* PHEV/HEV split (confirmed) | **New only, ACEA-style** | ⭐ **Build candidate #1** — see §Serbia below |
 | 🇧🇦 Bosnia | bhas.gov.ba monthly TRANSPORT bulletin (from IDDEEA) | monthly PDF | may lump "alternative fuel" (~3.6%) — **verify granularity** | first-reg **incl. imported used** (Albania-like) | Candidate — verify fuel split |
 | 🇲🇰 North Macedonia | stat.gov.mk | thin | thin | — | Weak (≈190 BEV total; signal too small) |
 | 🇲🇪 Montenegro | MONSTAT | ~annual | thin | — | Weak |
@@ -257,35 +258,49 @@ separates BEV/PHEV/HEV) → skip North Macedonia / Montenegro / Kosovo for now
 
 ### 🇷🇸 Serbia — verification status (2026-07)
 
-> **Status: PARTIALLY VERIFIED — endpoint not yet exercised.** The candidate
-> endpoint `uvoznicivozila.rs` (and the Eurostat/UNECE cross-check APIs) are
-> **egress-blocked by this session's network policy** (proxy returns 403 to
-> CONNECT). Substance below is corroborated from independent reporting
-> (SeeNews, Balkan Green Energy News, Serbian Monitor); the format/granularity
-> points marked ⚠ need a live probe from an environment with egress — build
-> `scripts/fetch_serbia.py --probe` on the India/Morocco/South-Africa pattern
-> and run it in CI, or have the maintainer fetch the monthly report manually.
+> **Status: DATA MODEL CONFIRMED from published reports; BUILD DEFERRED.** The
+> candidate endpoint `uvoznicivozila.rs` was **egress-blocked** in the
+> investigating session, so the maintainer pulled three reports manually
+> (Q1-2025, H1-2025, H1-2026). Findings below are from those actual reports, not
+> speculation. The domains `uvoznicivozila.rs`, `ec.europa.eu`, `w3.unece.org`
+> have since been **added to the environment's Custom network allowlist** — a
+> *new* session can fetch and probe directly. Build is deferred to that session.
 
-Checklist against the gallery bar and against how peer countries are sourced:
+Confirmed against the gallery bar and peer countries:
 
-| Criterion | Status | Notes |
+| Criterion | Status | Finding (from the actual reports) |
 |---|---|---|
-| (a) Primary / de-facto industry body | ✅ | Serbian Association of Importers of Vehicles & Parts (Uvoznici vozila); figures compiled (Cube Team) from **MoI first-registration** records — same class as AIVAM (Morocco), naamsa (South Africa) |
-| Scope = new M1 passenger cars | ✅ | reported as "first-time registrations of **new** passenger cars", category **M1** — genuinely ACEA-equivalent (unlike Albania's incl.-imported-used lens) |
-| Cadence monthly | ✅ (likely) | monthly *saopštenje* + YTD cumulative; confirm each month is separately reported (not only cumulative) |
-| BEV separated | ✅ | BEV reported distinctly (≈1.2% share 2025, +50% y/y) |
-| **PHEV vs HEV split** | ⚠ **RISK** | headlines cite "**all types of hybrids**" as one figure (Q1-2026 hybrids 43.2%). Likely a **single combined hybrid bucket** → if so, Serbia = the **Türkiye / Georgia / Colombia / Malaysia pattern** (show as 'Hybrid', count within ICE in the BEV/ICE/PHEV trajectory, add the standard combined-hybrid footnote). Confirm whether the monthly report sub-splits PHEV/HEV before assuming the full 6-way schema |
-| (b) Completeness — captures BYD / Chinese direct imports | ⚠ **VERIFY** | BYD launched in Serbia 2024/25; importers'-association series can miss non-member/direct importers (the recurring §14 BYD hole). Confirm BYD volume appears |
-| (c) Machine-access, no paywall/ID | ⚠ **VERIFY** | site reachable publicly, but table-in-HTML vs embedded-image vs PDF is unknown (drives fetcher shape). Not yet inspectable from CI egress here |
-| Fuel-split history depth | ⚠ VERIFY | how far back the powertrain breakdown runs (backfill vs live-only) |
+| (a) Primary / de-facto industry body | ✅ | Serbian Association of Importers of Vehicles & Parts (Uvoznici vozila); source line reads *"Ministry of Internal Affairs of the Republic of Serbia, Cube Team"* → **MoI first-registration** data. Same class as AIVAM / naamsa |
+| Scope = new M1 passenger cars | ✅ | "first registrations of **new** passenger vehicles (M1)"; N1 (LCV) and L (moto/moped) reported separately → genuinely ACEA-equivalent, and a multi-variant lead (M1=Whole, N1=Vans, L=2-Wheelers) like Spain |
+| BEV separated | ✅ | "Electric" is its own line (H1-2025: 161 = 0.98%) |
+| **PHEV vs HEV split** | ❌ **NO — combined** | reported as **"Hybrids (all types)"** in one bucket (H1-2025: 6,039 = 36.66%). No PHEV/HEV separation. ⟹ Serbia is the **Türkiye / Georgia / Colombia / Malaysia pattern**: map to a single 'Hybrid'/HEV column, PHEV stays 0/blank, count within ICE in the BEV/ICE/PHEV trajectory, add the standard combined-hybrid footnote |
+| Fuel categories | ✅ (maps cleanly) | Petrol→PETROL, Diesel→DIESEL, Hybrids(all)→HEV(combined), Electric→BEV, Other→OTHERS (LPG/CNG) |
+| **Cadence of the fuel split** | ⚠ **QUARTERLY, not monthly** | the *drivetrain* breakdown is published only per **quarter / half-year**. Monthly figures exist but only as **totals in prose** (e.g. "In January 2025, 1,492 passenger cars…"), **not** a monthly fuel split. So Serbia is a **quarterly-fuel-split** source (South-Africa-style cadence), or monthly-total + quarterly-mix |
+| (c) Machine-access / format | ⚠ **HTML PROSE ONLY** | **no PDF / Excel / API.** Numbers are embedded in article body text + bullet lists. Fragile: each period is a new article with an **unstable slug** (no stable listing/data endpoint found). A monthly auto-fetcher that guesses URLs will break — needs a news-index crawl or search-driven article discovery, to be worked out with live access |
+| (b) Completeness — BYD / Chinese direct imports | ⚠ VERIFY | brand lists seen were Škoda/Toyota/VW/Hyundai/Renault/BMW; confirm BYD/Chinese EVs appear once EV volume grows (the §14 completeness hole) |
+| Fuel-split history depth | ⚠ VERIFY | reports show current + prior-year comparison; how far back the quarterly split runs is unknown |
 
-**Consistency verdict.** Serbia slots in cleanly as an ACEA-style *national*
-source (new M1, monthly, industry body) — a better ACEA fit than Albania. The
-one open schema question is the hybrid split: if hybrids are combined it is
-**still fully consistent** with the repo, matching the documented combined-hybrid
-footnote pattern (Türkiye/Georgia/Colombia/Malaysia) rather than the full
-BEV/PHEV/HEV split (Albania/Singapore). Decide the schema from the probe, not
-before. Do **not** build the live fetcher until the ⚠ points are answered.
+**Captured reference data** (for future cross-check / bootstrap — M1 passenger, first registrations):
+
+| Period | Petrol | Diesel | Hybrids (all) | Electric | Other | Total |
+|---|---|---|---|---|---|---|
+| H1 2024 | 7,326 | 2,960 | 4,438 | 116 | 318 | 15,158 |
+| H1 2025 | 7,836 | 2,105 | 6,039 | 161 | 332 | 16,473 |
+| H1 2026 (total only) | — | — | — | — | — | 19,515 |
+
+Monthly M1 totals seen in prose: Jan-2025 1,492 · Feb-2025 1,888 · Mar-2025 2,673 (Q1 6,053); Apr-2025 3,786 (peak, Belgrade Auto Show effect). N1 (LCV) H1-2025 drivetrain: Petrol 299 / Diesel 1,814 / Other 207.
+
+**Consistency verdict.** Serbia is a genuine ACEA-style *national* source (new
+M1, industry body, MoI data) and a better ACEA fit than Albania — but **not the
+clean monthly full-split source first hoped for**. Two real constraints shape the
+build: (1) **combined hybrids** → it joins the Türkiye/Georgia/Colombia/Malaysia
+combined-hybrid pattern with the standard footnote (still fully repo-consistent),
+and (2) **quarterly fuel split in HTML prose with unstable article URLs** → the
+fetcher is closer to a quarterly / manual-cadence parser (South Africa / Türkiye
+class) than a monthly API scrape, and article discovery must be solved with live
+access. **Next step (new session, domains now allowed):** load the news index,
+work out stable article discovery, decide monthly-total-vs-quarterly-mix cadence,
+then build `scripts/fetch_serbia.py` + a §-source doc on the Albania/Israel model.
 
 ---
 

--- a/docs/architecture/33-expansion-candidates.md
+++ b/docs/architecture/33-expansion-candidates.md
@@ -255,6 +255,38 @@ ACEA-clean, growing EV signal) → Bosnia (only after confirming the bulletin
 separates BEV/PHEV/HEV) → skip North Macedonia / Montenegro / Kosovo for now
 (EV signal ≈ 0, monthly data too thin — same failure mode as the §14 rejects).
 
+### 🇷🇸 Serbia — verification status (2026-07)
+
+> **Status: PARTIALLY VERIFIED — endpoint not yet exercised.** The candidate
+> endpoint `uvoznicivozila.rs` (and the Eurostat/UNECE cross-check APIs) are
+> **egress-blocked by this session's network policy** (proxy returns 403 to
+> CONNECT). Substance below is corroborated from independent reporting
+> (SeeNews, Balkan Green Energy News, Serbian Monitor); the format/granularity
+> points marked ⚠ need a live probe from an environment with egress — build
+> `scripts/fetch_serbia.py --probe` on the India/Morocco/South-Africa pattern
+> and run it in CI, or have the maintainer fetch the monthly report manually.
+
+Checklist against the gallery bar and against how peer countries are sourced:
+
+| Criterion | Status | Notes |
+|---|---|---|
+| (a) Primary / de-facto industry body | ✅ | Serbian Association of Importers of Vehicles & Parts (Uvoznici vozila); figures compiled (Cube Team) from **MoI first-registration** records — same class as AIVAM (Morocco), naamsa (South Africa) |
+| Scope = new M1 passenger cars | ✅ | reported as "first-time registrations of **new** passenger cars", category **M1** — genuinely ACEA-equivalent (unlike Albania's incl.-imported-used lens) |
+| Cadence monthly | ✅ (likely) | monthly *saopštenje* + YTD cumulative; confirm each month is separately reported (not only cumulative) |
+| BEV separated | ✅ | BEV reported distinctly (≈1.2% share 2025, +50% y/y) |
+| **PHEV vs HEV split** | ⚠ **RISK** | headlines cite "**all types of hybrids**" as one figure (Q1-2026 hybrids 43.2%). Likely a **single combined hybrid bucket** → if so, Serbia = the **Türkiye / Georgia / Colombia / Malaysia pattern** (show as 'Hybrid', count within ICE in the BEV/ICE/PHEV trajectory, add the standard combined-hybrid footnote). Confirm whether the monthly report sub-splits PHEV/HEV before assuming the full 6-way schema |
+| (b) Completeness — captures BYD / Chinese direct imports | ⚠ **VERIFY** | BYD launched in Serbia 2024/25; importers'-association series can miss non-member/direct importers (the recurring §14 BYD hole). Confirm BYD volume appears |
+| (c) Machine-access, no paywall/ID | ⚠ **VERIFY** | site reachable publicly, but table-in-HTML vs embedded-image vs PDF is unknown (drives fetcher shape). Not yet inspectable from CI egress here |
+| Fuel-split history depth | ⚠ VERIFY | how far back the powertrain breakdown runs (backfill vs live-only) |
+
+**Consistency verdict.** Serbia slots in cleanly as an ACEA-style *national*
+source (new M1, monthly, industry body) — a better ACEA fit than Albania. The
+one open schema question is the hybrid split: if hybrids are combined it is
+**still fully consistent** with the repo, matching the documented combined-hybrid
+footnote pattern (Türkiye/Georgia/Colombia/Malaysia) rather than the full
+BEV/PHEV/HEV split (Albania/Singapore). Decide the schema from the probe, not
+before. Do **not** build the live fetcher until the ⚠ points are answered.
+
 ---
 
 ## Alternative axis — variant leads for countries already on the gallery

--- a/docs/architecture/33-expansion-candidates.md
+++ b/docs/architecture/33-expansion-candidates.md
@@ -240,6 +240,20 @@ country's underlying primary source.
 | 🇽🇰 Kosovo | Kosovo Agency of Statistics | ~annual | thin | — | Weak |
 | all (backfill/cross-check) | **Eurostat `road_eqr_carpda`** + **UNECE** road-fleet PX tables | **annual only, ~1yr lag** | motor-energy, ACEA-congruent | new | annual backfill / cross-check, not a monthly primary |
 
+**🇧🇦 Bosnia — findings (2026-07, web-research only).** Primary source is the
+**BHAS** monthly *TRANSPORT* statistical bulletin (`bhas.gov.ba`, First Release
+series), which draws registered-vehicle data from **IDDEEA** (Agency for
+Identification Documents, Registers and Data Exchange). Free HTML/PDF, monthly.
+Two open risks before building: (1) the fuel breakdown seen is coarse —
+2024 registered-car stock split as **diesel 77.6% / petrol 18.9% / alternative
+fuel 3.6%**, i.e. "alternative fuel" is likely a **single lumped bucket** with no
+BEV/PHEV/HEV separation → verify the monthly *flow* table is finer before
+building; (2) figures are **first registrations incl. imported used** (March-2025
+≈ 630 new passenger cars, petrol 52.8% / diesel 35.3% — a used-import-heavy
+mix), so Bosnia is Albania-lens, **needs the incl.-imported-used footnote** and
+is not ACEA-new-car comparable. Verdict: candidate, but only after confirming the
+monthly fuel granularity — could fail the fuel-split bar the way it stands.
+
 **ACEA-consistency caveat (matters for this region).** Only Serbia
 (importers' association) and the Eurostat/UNECE annuals are *new-car* series.
 The statistical-office / IDDEEA routes (Bosnia, and the same lens we already use

--- a/footnotes.csv
+++ b/footnotes.csv
@@ -7,10 +7,10 @@ Georgia,Whole,Source reports a single combined hybrid figure (no PHEV/HEV split)
 Colombia,Whole,Source reports a single combined hybrid figure (no PHEV/HEV split): shown as 'Hybrid' in the fuel-split chart; counted within ICE in the BEV/ICE/PHEV trajectory.
 Malaysia,Whole,Source (data.gov.my) does not split PHEV from HEV: shown as 'Hybrid' in the fuel-split chart; counted within ICE in the BEV/ICE/PHEV trajectory.
 Singapore,Whole,Monthly BEV/PHEV/HEV split reported by LTA from Jul 2022; earlier electrified cars sit in 'Others'. Pre-automation series compiled by R. Andrew.
-Albania,Whole,Figures include first registrations of both new and imported used vehicles. Historical series (pre-2026) compiled by R. Andrew from DPSHTRR open data.
-Albania,HDV,Figures include first registrations of both new and imported used vehicles. Pre-2026 series fetched directly from DPSHTRR open data (2020-2024); 2019 and 2025 unavailable.
-Albania,Buses,Figures include first registrations of both new and imported used vehicles. Pre-2026 series fetched directly from DPSHTRR open data (2020-2024); 2019 and 2025 unavailable.
-Albania,2-Wheelers,Figures include first registrations of both new and imported used vehicles. Pre-2026 series fetched directly from DPSHTRR open data (2020-2024); 2019 and 2025 unavailable.
+Albania,Whole,Figures are first registrations incl. imported used vehicles — not new-car sales and not comparable to ACEA new-registration counts. Historical series (pre-2026) compiled by R. Andrew from DPSHTRR open data.
+Albania,HDV,Figures are first registrations incl. imported used vehicles — not new-car sales and not comparable to ACEA new-registration counts. Pre-2026 series fetched directly from DPSHTRR open data (2020-2024); 2019 and 2025 unavailable.
+Albania,Buses,Figures are first registrations incl. imported used vehicles — not new-car sales and not comparable to ACEA new-registration counts. Pre-2026 series fetched directly from DPSHTRR open data (2020-2024); 2019 and 2025 unavailable.
+Albania,2-Wheelers,Figures are first registrations incl. imported used vehicles — not new-car sales and not comparable to ACEA new-registration counts. Pre-2026 series fetched directly from DPSHTRR open data (2020-2024); 2019 and 2025 unavailable.
 Spain,Whole,DGT registry data; includes M1 people movers (ID.Buzz / Multivan ...) that ANFAC/ACEA count as vans; totals ~2% above ACEA. Pre-Oct-2015 series by Asier Lizarraga.
 Spain,Rental,DGT registry data; new turismos & todoterrenos registered to short-term rental (alquiler sin conductor) or flagged as renting/leasing. Rental + NonRental = Whole.
 Spain,NonRental,DGT registry data; new turismos & todoterrenos excluding the rental & leasing channel. Rental + NonRental = Whole.


### PR DESCRIPTION
## Summary
This PR documents the investigation and verification status of vehicle registration data sources across the Western Balkans region (Serbia, Bosnia, North Macedonia, Montenegro, Kosovo) as expansion candidates for the gallery. It includes detailed findings from manual verification of Serbia's data model against published reports and clarifies the distinction between new-car sales and first-registration-inclusive-used data across the region.

## Key Changes

- **New expansion tier section (33-expansion-candidates.md):** Added comprehensive "Tier — Western Balkans / former Yugoslavia gap (2026-07)" documenting:
  - Comparative analysis table of primary sources across five countries
  - Detailed findings on Bosnia's BHAS/IDDEEA monthly transport bulletin
  - Critical caveat on ACEA-consistency: distinguishing new-car series (Serbia, Eurostat/UNECE) from first-registration-incl.-used series (Bosnia, Albania pattern)
  - Recommended order of attack prioritizing Serbia

- **Serbia verification subsection:** Added detailed "🇷🇸 Serbia — verification status (2026-07)" documenting:
  - Status: data model confirmed from three manually-pulled quarterly reports (Q1-2025, H1-2025, H1-2026)
  - Verification table confirming M1 scope, BEV separation, and industry body status
  - Critical finding: **combined hybrid reporting** (no PHEV/HEV split) — maps to existing Türkiye/Georgia/Colombia/Malaysia pattern
  - Critical finding: **quarterly fuel split cadence** in HTML prose with unstable URLs — requires news-index crawl for discovery
  - Reference data table with captured H1 2024/2025 figures and monthly totals
  - Build deferral rationale pending live access to test article discovery

- **Albania source documentation (27-source-albania.md):** Added clarification section on CEauto cross-check:
  - Documents 5× denominator gap (CEauto ~7,220 new-only vs our ~38,716 whole-flow for H1-2026)
  - Explains gap as used-import flow and validates our data as superset
  - Warns against reconciliation or "fixing" numbers to match trade press
  - Reinforces gallery's whole-flow market lens rationale

- **Footnotes.csv:** Updated Albania footnotes across all four categories (Whole, HDV, Buses, 2-Wheelers):
  - Clarified language from "include first registrations of both new and imported used vehicles" to "are first registrations incl. imported used vehicles — not new-car sales and not comparable to ACEA new-registration counts"
  - Strengthens distinction for future maintainers and cross-country comparisons

## Notable Implementation Details

- Serbia is confirmed as **ACEA-equivalent in scope** (new M1 from MoI data via industry body) but **not in cadence or format** (quarterly fuel split in unstable HTML prose vs. monthly API)
- The combined-hybrid pattern is documented as reusable across multiple countries; Serbia joins this established pattern with standard footnote
- Bosnia remains a candidate pending verification of monthly fuel granularity in the BHAS bulletin
- North Macedonia, Montenegro, Kosovo deferred due to weak EV signal and thin data
- Network allowlist has been updated to enable future live verification of `uvoznicivozila.rs`, `ec.europa.eu`, `w3.unece.org`

https://claude.ai/code/session_01JWnZDMt9fdjnQvQNh9WEYg