### PR TITLE
data: Germany (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/Germany.csv
+++ b/data/Germany.csv
@@ -173,3 +173,4 @@ period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,note
 2026-04,monthly,Whole,KBA,64350,27546,70207,53420,32437,1203,249163,first submission via page
 2026-05,monthly,Whole,KBA,59969,27921,67545,51806,30547,1660,239448,https://www.kba.de/DE/Presse/Pressemitteilungen/Fahrzeugzulassungen/2026/pm21_2026_n_05_26_pm_komplett.html
 2026-06,monthly,Whole,KBA,84057,32212,83315,60796,33862,2136,296378,https://www.kba.de/DE/Presse/Pressemitteilungen/Fahrzeugzulassungen/2026/pm25_2026_n_06_26_pm_komplett.html?snn=827402
+2026-07,monthly,Whole,KBA,78609,30609,74675,50732,31703,1740,268068,https://www.kba.de/DE/Presse/Pressemitteilungen/Fahrzeugzulassungen/2026/pm32_2026_n_07_26_pm_komplett.html?snn=827402


### PR DESCRIPTION
Submitted by **LeRaffl** via Submit Data form.

- **Country:** Germany
- **Variant:** Whole
- **Source:** KBA
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-07** (monthly) — BEV=78609, PHEV=30609, HEV=74675, PETROL=50732, DIESEL=31703, OTHERS=1740, TOTAL=268068

---

After merge, trigger the **Render country charts** Action to regenerate plots.