### PR TITLE
data: Australia (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/Australia.csv
+++ b/data/Australia.csv
@@ -76,3 +76,4 @@ period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,note
 2026-04,monthly,Whole,VFACTS & Prof. Ray Willis,15459,9628,18162,25399,22414,,91062,Check again for consistency
 2026-05,monthly,Whole,VFACTS & Prof. Ray Willis,21303,9315,19024,28692,25191,,103525,
 2026-06,monthly,Whole,VFACTS & Prof. Ray Willis,32570,16068,20741,34177,31789,,135345,
+2026-07,monthly,Whole,VFACTS & Prof. Ray Willis,25310,18684,10359,27894,24773,,107020,


### PR DESCRIPTION
Submitted by **LeRaffl** via Submit Data form.

- **Country:** Australia
- **Variant:** Whole
- **Source:** VFACTS & Prof. Ray Willis
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-07** (monthly) — BEV=25310, PHEV=18684, HEV=10359, PETROL=27894, DIESEL=24773, TOTAL=107020

---

After merge, trigger the **Render country charts** Action to regenerate plots.