### PR TITLE
data: New Zealand (Whole) — 1 added, 0 corrected

### DIFF
--- a/data/New Zealand.csv
+++ b/data/New Zealand.csv
@@ -173,3 +173,4 @@ period,time_interval,variant,source,BEV,PHEV,HEV,PETROL,DIESEL,OTHERS,TOTAL,note
 2026-04,monthly,Whole,transport.govt.nz & Prof. Ray Willis,1415,1273,6996,7265,2418,0,19367,https://www.transport.govt.nz/statistics-and-insights/fleet-statistics/light-motor-vehicle-registrations/
 2026-05,monthly,Whole,transport.govt.nz & Prof. Ray Willis,1962,1115,6792,6560,3261,,19690,
 2026-06,monthly,Whole,transport.govt.nz & Prof. Ray Willis,3144,1506,6946,6955,3668,,22219,
+2026-07,monthly,Whole,transport.govt.nz & Prof. Ray Willis,2387,1595,6963,6714,3065,,20724,


### PR DESCRIPTION
Submitted by **LeRaffl** via Submit Data form.

- **Country:** New Zealand
- **Variant:** Whole
- **Source:** transport.govt.nz & Prof. Ray Willis
- **Added:** 1
- **Corrected:** 0

### New rows
- **2026-07** (monthly) — BEV=2387, PHEV=1595, HEV=6963, PETROL=6714, DIESEL=3065, TOTAL=20724

---

After merge, trigger the **Render country charts** Action to regenerate plots.