### PR TITLE
fix(fetch): unblock Colombia and Albania, prepare the NL relay, diagnose Indonesia

### DIFF
--- a/scripts/fetch_albania.py
+++ b/scripts/fetch_albania.py
@@ -237,7 +237,31 @@ _FUEL_TYPE_HINTS = {
 
 # ── Session via headless browser ──────────────────────────────────────────────
 
-def _fetch_with_browser_session(year: int) -> dict:
+# Initial-load budget per attempt. The Looker report renders its Muaji filter
+# asynchronously and sometimes has not painted it when the first budget runs
+# out — the scrape then finds zero month labels and the whole run dies. That is
+# a slow load, not a changed report: the same code succeeds minutes later. Give
+# a stalled attempt progressively more room instead of failing the day.
+LOAD_ATTEMPT_WAITS = (35, 70, 110)
+
+
+def _fetch_year_with_retries(year: int) -> dict:
+    """Run the browser scrape, retrying with a longer load budget on failure."""
+    last_exc: Exception | None = None
+    for attempt, wait in enumerate(LOAD_ATTEMPT_WAITS, start=1):
+        try:
+            return _fetch_with_browser_session(year, initial_wait=wait)
+        except Exception as exc:
+            last_exc = exc
+            if attempt < len(LOAD_ATTEMPT_WAITS):
+                print(f"[albania] [{year}] attempt {attempt}/{len(LOAD_ATTEMPT_WAITS)} "
+                      f"failed ({exc}); retrying with a {LOAD_ATTEMPT_WAITS[attempt]}s "
+                      f"load budget")
+    assert last_exc is not None
+    raise last_exc
+
+
+def _fetch_with_browser_session(year: int, initial_wait: int = 35) -> dict:
     """
     Load the year-specific Albanian DPSHTRR Looker Studio report in headless
     Chromium, intercept all batchedDataV2 responses, and iterate the Muaji
@@ -362,9 +386,9 @@ def _fetch_with_browser_session(year: int) -> dict:
                 print(f"[albania][debug] phase-2 landed: {page.url}")
 
         # Wait for initial page load + batchedDataV2 responses
-        print("[albania] waiting 35s for initial load…")
+        print(f"[albania] waiting {initial_wait}s for initial load…")
         initial_start = len(captured)
-        deadline = _time.time() + 35
+        deadline = _time.time() + initial_wait
         while _time.time() < deadline:
             page.wait_for_timeout(500)
 
@@ -909,7 +933,7 @@ def main() -> None:
     all_rows: dict = {}
     for year in years:
         print(f"\n[albania] ── year {year} ──")
-        fetched = _fetch_with_browser_session(year)
+        fetched = _fetch_year_with_retries(year)
         rows = _difference_to_rows(fetched)
         if not rows:
             print(f"[albania] WARNING: no rows parsed for {year} — "

--- a/scripts/fetch_albania.py
+++ b/scripts/fetch_albania.py
@@ -444,6 +444,22 @@ def _fetch_with_browser_session(year: int) -> dict:
 }
 """
 
+        # Diagnostic companion to _JS_MONTH_LABELS: every short leaf-ish text in
+        # the live DOM, so a changed month-label format shows up in the log.
+        _JS_POPUP_SAMPLE = r"""
+() => {
+    const out = []; const seen = new Set();
+    for (const e of document.querySelectorAll('span,div,label,li,td')) {
+        if (e.closest('svg')) continue;
+        const t = (e.textContent || '').trim();
+        if (!t || t.length > 40 || seen.has(t)) continue;
+        seen.add(t); out.push(t);
+        if (out.length >= 80) break;
+    }
+    return JSON.stringify(out);
+}
+"""
+
         def _label_to_period(label: str) -> str | None:
             try:
                 abbr, yr = label.split()
@@ -494,6 +510,15 @@ def _fetch_with_browser_session(year: int) -> dict:
         print(f"[albania] [{year}] Muaji months present (descending): {present_periods}")
 
         if not present:
+            # The popup opened but nothing matched "<Mon> <YYYY>". Dump what the
+            # popup actually contains before giving up — otherwise a relabelled
+            # or restructured filter is indistinguishable from a load timeout,
+            # and the run just fails with an opaque message every day.
+            try:
+                sample = json.loads(page.evaluate(_JS_POPUP_SAMPLE))
+            except Exception as exc:
+                sample = [f"<sample failed: {exc}>"]
+            print(f"[albania] [{year}] popup text sample ({len(sample)} items): {sample}")
             browser.close()
             raise RuntimeError(
                 "[albania] no month labels found in the Muaji popup")

--- a/scripts/fetch_colombia.py
+++ b/scripts/fetch_colombia.py
@@ -58,6 +58,8 @@ from datetime import date
 from pathlib import Path
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 CAMARA_URL = "https://www.andi.com.co/Home/Camara/4-automotriz"
 SOURCE = "andi.com.co + fenalco (datos RUNT)"
@@ -280,6 +282,18 @@ def main() -> None:
 
     session = requests.Session()
     session.headers.update({"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"})
+    # andi.com.co intermittently drops the connection mid-handshake, which
+    # surfaced as a hard `RemoteDisconnected` on the very first GET and failed
+    # the whole scheduled run. Retry connect/read errors and the usual
+    # transient status codes with backoff (same shape as fetch_austria.py).
+    session.mount("https://", HTTPAdapter(max_retries=Retry(
+        total=5,
+        connect=5,
+        read=3,
+        backoff_factor=3,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )))
 
     if args.pdf_url:
         url, year, n = args.pdf_url, None, None

--- a/scripts/fetch_indonesia.py
+++ b/scripts/fetch_indonesia.py
@@ -219,6 +219,7 @@ class ParsedPdf:
         self.coverage = None     # (last covered month, year)
         self.unknown_fuels = defaultdict(int)
         self.warnings = []
+        self.sections_without_fuel_column = 0
 
 
 def process_region(rows, key, parsed):
@@ -230,6 +231,8 @@ def process_region(rows, key, parsed):
         # month tokens the sheet actually prints. find_month_bands insists on
         # all 12; a sheet trimmed to the covered months would fail here with no
         # way to tell that apart from a wholesale layout change.
+        if fuel_cx is None:
+            parsed.sections_without_fuel_column += 1
         detail = []
         if bands is None:
             detail.append("month header not found")
@@ -244,9 +247,12 @@ def process_region(rows, key, parsed):
             # header band's actual tokens so a renamed column is readable from
             # the log instead of guessed at.
             if hdr_top is not None:
-                for r in rows:
-                    if abs(r["top"] - hdr_top) <= 20:
-                        detail.append(f"header-band row {r['text'][:120]!r}")
+                # Just the header block: the rows immediately above the month
+                # row plus the unit line under it. A wider window drags in
+                # model rows and buries the answer.
+                band = [r for r in rows if hdr_top - 8 <= r["top"] <= hdr_top + 4]
+                for r in band[:5]:
+                    detail.append(f"header-band row {r['text'][:120]!r}")
         parsed.warnings.append(f"{key}: " + "; ".join(detail))
         return
 
@@ -378,6 +384,26 @@ def validate(parsed):
     """Cross-check every layer against the printed totals; exit on mismatch."""
     last_month, year = parsed.coverage
     errors = []
+
+    # Every sheet title matched but not one carried a FUEL column: that is the
+    # source dropping the fuel dimension, not the parser losing its place.
+    # Verified against GAIKINDO's Jan-Jul 2026 edition — its sheets run
+    # CATEGORY | BRAND | TYPE/MODEL | CC | TRANS | CO2 | ... | ORIGIN COUNTRY |
+    # JAN..DEC, with no FUEL column and no BEV/PHEV/HEV token anywhere in the
+    # document; the only fuel marker left is the [G/D] / [G] / [D] label on the
+    # category block, which describes a whole block rather than a row. The
+    # Jan-Jun edition still had the column. Nothing to parse, so say that
+    # plainly instead of emitting a wall of downstream validation noise.
+    if parsed.sections_without_fuel_column and not parsed.sections:
+        for w in parsed.warnings:
+            print(f"warning: {w}")
+        raise SystemExit(
+            f"GAIKINDO's Jan-{MONTH_NAMES[last_month - 1].title()} {year} sheets have no "
+            f"FUEL column ({parsed.sections_without_fuel_column} section(s) affected), so "
+            f"this edition carries no BEV/PHEV/HEV/petrol/diesel split. The fuel breakdown "
+            f"has to come back to the source before this can be parsed — check the portal "
+            f"for a corrected or separate fuel-split file."
+        )
 
     missing = ALL_SECTIONS - set(parsed.sections)
     if missing:

--- a/scripts/fetch_indonesia.py
+++ b/scripts/fetch_indonesia.py
@@ -398,11 +398,13 @@ def validate(parsed):
         for w in parsed.warnings:
             print(f"warning: {w}")
         raise SystemExit(
-            f"GAIKINDO's Jan-{MONTH_NAMES[last_month - 1].title()} {year} sheets have no "
-            f"FUEL column ({parsed.sections_without_fuel_column} section(s) affected), so "
-            f"this edition carries no BEV/PHEV/HEV/petrol/diesel split. The fuel breakdown "
-            f"has to come back to the source before this can be parsed — check the portal "
-            f"for a corrected or separate fuel-split file."
+            f"GAIKINDO's Jan-{MONTH_NAMES[last_month - 1].title()} {year} wholesales sheets "
+            f"have no FUEL column ({parsed.sections_without_fuel_column} section(s) affected), "
+            f"so this edition carries no BEV/PHEV/HEV/petrol/diesel split and there is "
+            f"nothing to parse. Most likely a bad edition rather than a format change: the "
+            f"production, export and import files published alongside it still carry the "
+            f"column, and GAIKINDO does re-publish revisions. Wait for a corrected wholesales "
+            f"file, or re-run with --pdf-url pointing at one."
         )
 
     missing = ALL_SECTIONS - set(parsed.sections)

--- a/scripts/fetch_indonesia.py
+++ b/scripts/fetch_indonesia.py
@@ -226,7 +226,21 @@ def process_region(rows, key, parsed):
     bands, hdr_top = find_month_bands(rows)
     fuel_cx = find_fuel_x(rows)
     if bands is None or fuel_cx is None:
-        parsed.warnings.append(f"{key}: month header or FUEL column not found")
+        # Say which of the two is missing, and — for the month header — which
+        # month tokens the sheet actually prints. find_month_bands insists on
+        # all 12; a sheet trimmed to the covered months would fail here with no
+        # way to tell that apart from a wholesale layout change.
+        detail = []
+        if bands is None:
+            detail.append("month header not found")
+            for r in rows:
+                found = [w["text"] for w in r["words"] if w["text"] in MONTH_NAMES]
+                if len(found) >= 2:
+                    detail.append(f"candidate header row {r['text'][:90]!r} "
+                                  f"-> {len(found)} month tokens {found}")
+        if fuel_cx is None:
+            detail.append("FUEL column not found")
+        parsed.warnings.append(f"{key}: " + "; ".join(detail))
         return
 
     fuel_rows, orphans, cumulative_tops = [], [], []

--- a/scripts/fetch_indonesia.py
+++ b/scripts/fetch_indonesia.py
@@ -240,6 +240,13 @@ def process_region(rows, key, parsed):
                                   f"-> {len(found)} month tokens {found}")
         if fuel_cx is None:
             detail.append("FUEL column not found")
+            # find_fuel_x wants a word whose text is exactly "FUEL". Show the
+            # header band's actual tokens so a renamed column is readable from
+            # the log instead of guessed at.
+            if hdr_top is not None:
+                for r in rows:
+                    if abs(r["top"] - hdr_top) <= 20:
+                        detail.append(f"header-band row {r['text'][:120]!r}")
         parsed.warnings.append(f"{key}: " + "; ".join(detail))
         return
 

--- a/scripts/fetch_indonesia.py
+++ b/scripts/fetch_indonesia.py
@@ -405,15 +405,19 @@ def validate(parsed):
         if seg_sum != sec:
             errors.append(f"PU_TRUCK segments {year}-{mi:02d}: {seg_sum} != section {sec}")
 
-    if errors:
-        for e in errors:
-            print(f"VALIDATION: {e}", file=sys.stderr)
-        raise SystemExit(f"PDF validation failed with {len(errors)} error(s)")
-
+    # Print the parser's own warnings *before* the validation verdict. They used
+    # to come after, so a failing run swallowed them — and they are exactly what
+    # explains the failure: "unmatched sheet title" names the heading GAIKINDO
+    # actually printed when a section goes missing.
     for w in parsed.warnings:
         print(f"warning: {w}")
     for tok, n in parsed.unknown_fuels.items():
         print(f"warning: unknown fuel type {tok!r} in {n} row(s) -> OTHERS")
+
+    if errors:
+        for e in errors:
+            print(f"VALIDATION: {e}", file=sys.stderr)
+        raise SystemExit(f"PDF validation failed with {len(errors)} error(s)")
 
 
 # ---------------------------------------------------------------- aggregation

--- a/scripts/fetch_netherlands.py
+++ b/scripts/fetch_netherlands.py
@@ -54,7 +54,7 @@ import sys
 import time
 from datetime import date
 from pathlib import Path
-from urllib.parse import quote as urlquote
+from urllib.parse import quote as urlquote, urljoin
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -119,6 +119,11 @@ NL_MONTHS = {
 WSGUID_RE = re.compile(r'WsGuid:\s*"([a-f0-9-]{36})"')
 DATE_RE = re.compile(r"(\d{1,2})\s+(\w+)\s+(\d{4})")
 
+# Relay redirect chain: followed client-side so the cookie jar in
+# session.relay_cookies travels with it (see _get / _relay_once).
+REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+MAX_RELAY_REDIRECTS = 10
+
 
 def _get(session: requests.Session, url: str,
          headers: dict | None = None, **kwargs) -> requests.Response:
@@ -142,6 +147,30 @@ def _get(session: requests.Session, url: str,
     if not relay_base:
         return session.get(url, headers=merged_headers, **kwargs)
 
+    target = url
+    for hop in range(MAX_RELAY_REDIRECTS + 1):
+        resp = _relay_once(session, target, merged_headers, **kwargs)
+        if resp.status_code not in REDIRECT_STATUSES:
+            return resp
+        # No X-Upstream-Location means the deployed relay predates manual-
+        # redirect support and followed the chain itself; hand the response
+        # back rather than guessing where it wanted to go.
+        location = resp.headers.get("X-Upstream-Location")
+        if not location:
+            return resp
+        target = urljoin(target, location)
+        print(f"[net] relay redirect {resp.status_code} (hop {hop + 1}) -> {target}")
+
+    raise RuntimeError(
+        f"[net] more than {MAX_RELAY_REDIRECTS} relay redirects starting at {url} — "
+        f"upstream is looping; last target {target}"
+    )
+
+
+def _relay_once(session: requests.Session, url: str, merged_headers: dict,
+                **kwargs) -> requests.Response:
+    """One relay round-trip, harvesting upstream Set-Cookie into the jar."""
+    relay_base = session.relay_base  # type: ignore[attr-defined]
     relay_token = getattr(session, "relay_token", "")
     relay_cookies: dict = getattr(session, "relay_cookies", {})
 
@@ -149,6 +178,10 @@ def _get(session: requests.Session, url: str,
         "X-Relay-Token":          relay_token,
         "X-Fwd-User-Agent":       HTTP_HEADERS["User-Agent"],
         "X-Fwd-Accept-Language":  HTTP_HEADERS["Accept-Language"],
+        # Own the redirect chain here: the relay's own fetch has no cookie jar,
+        # so a session-cookie redirect loop on databank.nl exhausted its 20-hop
+        # limit and came back as a 502. See worker/deno-relay.ts.
+        "X-Relay-Redirect":       "manual",
     }
     if relay_cookies:
         fwd["X-Fwd-Cookie"] = "; ".join(f"{k}={v}" for k, v in relay_cookies.items())

--- a/worker/deno-relay.ts
+++ b/worker/deno-relay.ts
@@ -17,7 +17,11 @@
 //   X-Fwd-Cookie            → forwarded upstream as Cookie
 //   X-Fwd-Referer           → forwarded upstream as Referer
 //   X-Fwd-Accept-Language   → forwarded upstream as Accept-Language
+//   X-Relay-Redirect: manual → do NOT follow upstream redirects; return the
+//                              3xx as-is and put its Location into the
+//                              X-Upstream-Location response header
 //   response X-Upstream-Set-Cookie ← upstream Set-Cookie headers, \n-joined
+//   response X-Upstream-Location   ← upstream Location (manual redirect mode)
 
 const ALLOW_HOSTS = new Set([
   "duurzamemobiliteit.databank.nl", // Netherlands (RDW via Swing)
@@ -93,9 +97,21 @@ Deno.serve(async (req: Request) => {
     if (fwdReferer) upstreamHeaders["Referer"] = fwdReferer;
     if (fwdLang) upstreamHeaders["Accept-Language"] = fwdLang;
 
+    // Redirect handling. `fetch` follows redirects itself by default, but it
+    // carries no cookie jar across the hops — so a site that redirects until
+    // its session cookie comes back (Swing/databank.nl does exactly that)
+    // loops until the runtime aborts with "Maximum number of redirects (20)
+    // reached", surfacing here as a 502. In manual mode we hand the 3xx back
+    // to the client, which owns the cookie jar and re-enters the relay for the
+    // next hop. Opt-in so existing callers (Austria) keep the old behaviour.
+    const manualRedirect = req.headers.get("X-Relay-Redirect") === "manual";
+
     let upstream: Response;
     try {
-      upstream = await fetch(t.toString(), { headers: upstreamHeaders });
+      upstream = await fetch(t.toString(), {
+        headers: upstreamHeaders,
+        redirect: manualRedirect ? "manual" : "follow",
+      });
     } catch (e) {
       return new Response(`relay upstream error: ${e}`, { status: 502 });
     }
@@ -108,6 +124,13 @@ Deno.serve(async (req: Request) => {
     if (setCookies.length > 0) {
       // \n-joined then base64'd: header values can't carry raw newlines.
       responseHeaders["X-Upstream-Set-Cookie-B64"] = b64utf8(setCookies.join("\n"));
+    }
+    // Deliberately NOT re-emitted as a real `Location`: the client's requests
+    // session would follow it straight to the upstream host, bypassing the
+    // relay and hitting the block the relay exists to route around.
+    const upstreamLocation = upstream.headers.get("Location");
+    if (manualRedirect && upstreamLocation) {
+      responseHeaders["X-Upstream-Location"] = upstreamLocation;
     }
 
     // Buffer the body rather than streaming upstream.body through. Streaming a


### PR DESCRIPTION
Four scheduled fetch workflows were red on `master`. Three are addressed here; Indonesia turned out to be a source-data problem, not a parser bug — see below.

## Colombia — fixed, verified green

```
ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

`andi.com.co` dropped the connection on the very first GET (`fetch_colombia.py:98`) and the whole run died. The session had no retry adapter at all, unlike the other fetchers. Mounted the same `Retry`/backoff adapter `fetch_austria.py` uses (connect+read retries, `backoff_factor=3`, 429/5xx in the forcelist).

Dispatched against this branch: **success**.

## Albania — fixed, verified green

```
[albania] [2026] Muaji months present (descending): []
RuntimeError: [albania] no month labels found in the Muaji popup
```

Red 4 days running, plus sporadic failures before that. It is **not** a changed report: dispatched unmodified against this branch it succeeded and returned July (`Whole 2026-07: BEV=615 … TOTAL=7730`). The Looker report paints the Muaji filter asynchronously and sometimes has not finished inside the fixed 35 s budget, and a single stalled load killed the day.

`_fetch_year_with_retries` now retries the scrape with a growing load budget (35 s → 70 s → 110 s) before giving up, and a failing attempt dumps a sample of the popup's real text so a genuine relabelling stays distinguishable from a slow load.

Dispatched against this branch: **success**.

## Netherlands — code ready, needs a relay redeploy to take effect

```
502 … relay upstream error: TypeError: Fetch failed: Maximum number of redirects (20) reached
```

The Deno relay's `fetch` follows redirects itself but keeps no cookie jar, so databank.nl's session-cookie redirect bounced until the runtime gave up. Fix is split across both sides:

- `worker/deno-relay.ts` — opt-in `X-Relay-Redirect: manual`: return the 3xx as-is with the target in `X-Upstream-Location`. Deliberately **not** re-emitted as a real `Location`, or the client's `requests` session would follow it straight to the upstream host and bypass the relay. Opt-in so the Austria caller keeps the old behaviour.
- `scripts/fetch_netherlands.py` — `_get` walks the redirect chain itself (max 10 hops) via `_relay_once`, harvesting `Set-Cookie` at every hop into the existing jar.

**Action required:** the relay runs as a Deno Deploy playground, so this only takes effect once `worker/deno-relay.ts` is redeployed there. Until then the deployed relay ignores the new header and the workflow keeps failing exactly as before — confirmed by a dispatch against this branch, which returned the identical 502 with no new error. The client degrades gracefully: no `X-Upstream-Location` means it hands the response back rather than guessing.

## Indonesia — a bad wholesales edition, not a format change

Diagnosed against the actual Jan–Jul 2026 wholesales PDF. Login, download and all seven sheet titles are fine, and the `JAN..DEC` month header is found — but **no sheet has a FUEL column**. The columns now run:

```
CATEGORY | BRAND | TYPE/MODEL | CC | TRANS | CO2 | TANK CAPT | GVW | GEAR RATIO |
WHEEL & TYRE SIZE | PS/HP | WHEEL BASE | DIMENSION | SEATER | DRIVE SYS. | SPEED |
DOOR | WHEELS | CBU/CKD | ORIGIN COUNTRY | JAN … DEC | SHARE | TOTAL
```

Checks run against the file:

- no `FUEL` token anywhere in the document (0 hits across all 4 pages);
- no `BEV` / `PHEV` / `HEV` token anywhere either — the only fuel markers left are `[G/D]`, `[G]`, `[D]`, `(G/D)`, and those label a whole **category block**, not a row;
- the x-gap where the FUEL column used to sit (≈128–151 pt) holds nothing but spillover from long brand names, and there is no rotated text hiding there (checked at char level: 0 non-upright chars).

The Jan–Jun edition still had the column — `data/Indonesia.csv` has `2026-06` with BEV 12695 / PHEV 2397 / HEV 7882.

**The sibling files rule out a format change.** GAIKINDO's production, export and import files for the same period all still carry a FUEL column, populated with exactly the vocabulary this parser already maps:

| file | FUEL column | fuel codes found |
|---|---|---|
| wholesales | ✗ | — |
| production | ✓ (x ≈ 304.7) | `G` ×350, `D` ×142, `BEV` ×48, `HEV` ×36, `PHEV` ×13 |
| export | ✓ | `BEV` ×46, `HEV` ×54, `PHEV` ×36 |
| import | ✓ | `BEV` ×68, `HEV` ×42, `PHEV` ×8 |
| brand | ✗ | none |

So the wholesales file losing the column reads as a bad edition rather than a deliberate restructuring, and GAIKINDO does re-publish revisions. The call is to wait for a corrected wholesales file; production is a different measure (Jan–Jul production totals 728,651 against wholesales of roughly 50–56k/month, since Indonesia produces heavily for export) and is not substituted here.

What this PR changes for Indonesia is that the failure now says all of that. Previously the parser warnings printed only *after* validation passed, so every failing run swallowed exactly the lines that explain it, and the log showed five downstream "sections missing" errors instead. Now:

- parser warnings print before the verdict;
- a missing month header or FUEL column reports the header block it actually found (trimmed to the header rows — a ±20 pt window dragged in model rows and buried the answer);
- the specific case "titles matched, but not one sheet has a FUEL column" exits with a message naming it.

```
GAIKINDO's Jan-Jul 2026 wholesales sheets have no FUEL column (8 section(s) affected),
so this edition carries no BEV/PHEV/HEV/petrol/diesel split and there is nothing to
parse. Most likely a bad edition rather than a format change: the production, export
and import files published alongside it still carry the column, and GAIKINDO does
re-publish revisions. Wait for a corrected wholesales file, or re-run with --pdf-url
pointing at one.
```

The guard only fires when zero sections parsed, so a healthy edition is unaffected.

## Verification

| Workflow | Checked | Result |
|---|---|---|
| Colombia | dispatched on this branch | success |
| Albania | dispatched on this branch (dry-run) | success, July parsed |
| Netherlands | dispatched on this branch | same 502 — inert until the relay is redeployed |
| Indonesia | parser run locally against the real Jan–Jul 2026 PDF | exits with the message above |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DSH3qMPJefUimbNLQbZa2